### PR TITLE
Added Pythis cards: fermion-pair production at 240 GeV; and updated (…

### DIFF
--- a/FCCee/Generator/Pythia8/p8_ee_H_Hbb_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_H_Hbb_ecm125.cmd
@@ -13,6 +13,17 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 HiggsSM:ffbar2H = on

--- a/FCCee/Generator/Pythia8/p8_ee_H_Hcc_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_H_Hcc_ecm125.cmd
@@ -13,6 +13,17 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 HiggsSM:ffbar2H = on

--- a/FCCee/Generator/Pythia8/p8_ee_H_Hgg_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_H_Hgg_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 HiggsSM:ffbar2H = on

--- a/FCCee/Generator/Pythia8/p8_ee_H_Htautau_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_H_Htautau_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 HiggsSM:ffbar2H = on

--- a/FCCee/Generator/Pythia8/p8_ee_WW_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_WW_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 WeakDoubleBoson:ffbar2WW = on

--- a/FCCee/Generator/Pythia8/p8_ee_ZZ_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_ZZ_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 WeakDoubleBoson:ffbar2gmZgmZ = on

--- a/FCCee/Generator/Pythia8/p8_ee_Z_Zbb_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Z_Zbb_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 WeakSingleBoson:ffbar2ffbar(s:gmZ) = on

--- a/FCCee/Generator/Pythia8/p8_ee_Z_Zcc_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Z_Zcc_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 WeakSingleBoson:ffbar2ffbar(s:gmZ) = on

--- a/FCCee/Generator/Pythia8/p8_ee_Z_Zqq_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Z_Zqq_ecm125.cmd
@@ -13,6 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 3) Hard process : ttbar pair production at 100TeV
 Beams:eCM = 125  ! CM energy of collision
 WeakSingleBoson:ffbar2ffbar(s:gmZ) = on

--- a/FCCee/Generator/Pythia8/p8_ee_Z_Ztautau_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Z_Ztautau_ecm125.cmd
@@ -13,7 +13,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e+ = 11
 Beams:idB = -11                   ! second beam, e- = -11
 
-! 3) Hard process : ttbar pair production at 100TeV
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 Beams:eCM = 125  ! CM energy of collision
 WeakSingleBoson:ffbar2ffbar(s:gmZ) = on
 

--- a/FCCee/Generator/Pythia8/p8_ee_Zll_ecm240.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Zll_ecm240.cmd
@@ -37,4 +37,4 @@ PartonLevel:FSR = on               ! final-state radiation
 ! Decays
 !Z0
 23:onMode = off
-23:onIfAny = 1 2 3 4 5 6
+23:onIfAny = 11 13 15


### PR DESCRIPTION
…BES + vertex) p8 cards for sqrts = 125 GeV

For sqrts = 125 GeV: the relative energy spread is taken to be identical to that at 91 GeV.