### PR TITLE
Add noBES Pythia8 cards for resonant Higgs prod at 125 GeV (with BES,…

### DIFF
--- a/FCCee/Generator/Pythia8/p8_ee_Zee_ecm91.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Zee_ecm91.cmd
@@ -21,12 +21,20 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e = 2212, pbar = -2212
 Beams:idB = -11                   ! second beam, e = 2212, pbar = -2212
 
+! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0602
+Beams:sigmaPzB = 0.0602
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
 ! 4) Hard process : Z->qqbar at Ecm=91 GeV
 Beams:eCM = 91.188  ! CM energy of collision
-
 
 WeakSingleBoson:ffbar2gmZ = on
 23:onMode = off
 23:onIfAny = 11
-22:onMode = off
-22:onIfAny = 11

--- a/FCCee/Generator/Pythia8/p8_ee_Zmumu_ecm91.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Zmumu_ecm91.cmd
@@ -21,6 +21,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e = 2212, pbar = -2212
 Beams:idB = -11                   ! second beam, e = 2212, pbar = -2212
 
+! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0602
+Beams:sigmaPzB = 0.0602
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 4) Hard process : Z->qqbar at Ecm=91 GeV
 Beams:eCM = 91.188  ! CM energy of collision
 
@@ -28,5 +40,3 @@ Beams:eCM = 91.188  ! CM energy of collision
 WeakSingleBoson:ffbar2gmZ = on
 23:onMode = off
 23:onIfAny = 13
-22:onMode = off
-22:onIfAny = 13

--- a/FCCee/Generator/Pythia8/p8_ee_Ztautau_ecm91.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Ztautau_ecm91.cmd
@@ -21,6 +21,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e = 2212, pbar = -2212
 Beams:idB = -11                   ! second beam, e = 2212, pbar = -2212
 
+! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0602
+Beams:sigmaPzB = 0.0602
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 4) Hard process : Z->qqbar at Ecm=91 GeV
 Beams:eCM = 91.188  ! CM energy of collision
 

--- a/FCCee/Generator/Pythia8/p8_ee_Ztautau_ecm91_EvtGen_Tau2MuGamma.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Ztautau_ecm91_EvtGen_Tau2MuGamma.cmd
@@ -20,6 +20,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e = 2212, pbar = -2212
 Beams:idB = -11                   ! second beam, e = 2212, pbar = -2212
 
+! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0602
+Beams:sigmaPzB = 0.0602
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 4) Hard process : Z->qqbar at Ecm=91 GeV
 Beams:eCM = 91.188  ! CM energy of collision
 

--- a/FCCee/Generator/Pythia8/p8_ee_Ztautau_ecm91_EvtGen_Tau2MuMuMu.cmd
+++ b/FCCee/Generator/Pythia8/p8_ee_Ztautau_ecm91_EvtGen_Tau2MuMuMu.cmd
@@ -20,6 +20,18 @@ Next:numberShowEvent = 0           ! print event record n times
 Beams:idA = 11                   ! first beam, e = 2212, pbar = -2212
 Beams:idB = -11                   ! second beam, e = 2212, pbar = -2212
 
+! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
+Beams:allowMomentumSpread  = on
+Beams:sigmaPzA = 0.0602
+Beams:sigmaPzB = 0.0602
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
+Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
+Beams:sigmaVertexZ = 0.30      !  0.30 mm
+
+
 ! 4) Hard process : Z->qqbar at Ecm=91 GeV
 Beams:eCM = 91.188  ! CM energy of collision
 

--- a/FCCee/Generator/Pythia8/p8_noBES_ee_H_Hbb_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_noBES_ee_H_Hbb_ecm125.cmd
@@ -1,25 +1,22 @@
 Random:setSeed = on
-Main:numberOfEvents = 1000         ! number of events to generate
 Main:timesAllowErrors = 5          ! how many aborts before run stops
-
+PDF:lepton = on
 
 ! 2) Settings related to output in init(), next() and stat().
 Init:showChangedSettings = on      ! list changed settings
 Init:showChangedParticleData = off ! list changed particle data
-Next:numberCount = 100            ! print message every n events
+Next:numberCount = 100             ! print message every n events
 Next:numberShowInfo = 1            ! print event information n times
 Next:numberShowProcess = 1         ! print process record n times
 Next:numberShowEvent = 0           ! print event record n times
-Stat:showPartonLevel = off
 
-! 3) Beam parameter settings. Values below agree with default ones.
-Beams:idA = 11                   ! first beam, e- = 11
-Beams:idB = -11                  ! second beam, e+ = -11
+Beams:idA = 11                   ! first beam, e+ = 11
+Beams:idB = -11                   ! second beam, e- = -11
 
-! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
-Beams:allowMomentumSpread  = on
-Beams:sigmaPzA = 0.0602
-Beams:sigmaPzB = 0.0602
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = off
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
 
 ! Vertex smearing :
 Beams:allowVertexSpread = on
@@ -27,14 +24,15 @@ Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
 Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
 Beams:sigmaVertexZ = 0.30      !  0.30 mm
 
-! 4) Hard process : qq, at 365 GeV
-Beams:eCM = 91.188               ! CM energy of collision
-WeakSingleBoson:ffbar2ffbar(s:gmZ) = on
+! 3) Hard process : ttbar pair production at 100TeV
+Beams:eCM = 125  ! CM energy of collision
+HiggsSM:ffbar2H = on
 
+! 4) Settings for the event generation process in the Pythia8 library.
 PartonLevel:ISR = on               ! initial-state radiation
 PartonLevel:FSR = on               ! final-state radiation
 
-! Decays
-!Z0
-23:onMode = off
-23:onIfAny = 1 2 3 4 5 6
+! 5) Non-standard settings; exemplifies tuning possibilities.
+25:m0       = 125.0               ! Higgs mass
+25:onMode   = off
+25:onIfAny  = 5

--- a/FCCee/Generator/Pythia8/p8_noBES_ee_H_Hcc_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_noBES_ee_H_Hcc_ecm125.cmd
@@ -1,25 +1,22 @@
 Random:setSeed = on
-Main:numberOfEvents = 1000         ! number of events to generate
 Main:timesAllowErrors = 5          ! how many aborts before run stops
-
+PDF:lepton = on
 
 ! 2) Settings related to output in init(), next() and stat().
 Init:showChangedSettings = on      ! list changed settings
 Init:showChangedParticleData = off ! list changed particle data
-Next:numberCount = 100            ! print message every n events
+Next:numberCount = 100             ! print message every n events
 Next:numberShowInfo = 1            ! print event information n times
 Next:numberShowProcess = 1         ! print process record n times
 Next:numberShowEvent = 0           ! print event record n times
-Stat:showPartonLevel = off
 
-! 3) Beam parameter settings. Values below agree with default ones.
-Beams:idA = 11                   ! first beam, e- = 11
-Beams:idB = -11                  ! second beam, e+ = -11
+Beams:idA = 11                   ! first beam, e+ = 11
+Beams:idB = -11                   ! second beam, e- = -11
 
-! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
-Beams:allowMomentumSpread  = on
-Beams:sigmaPzA = 0.0602
-Beams:sigmaPzB = 0.0602
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = off
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
 
 ! Vertex smearing :
 Beams:allowVertexSpread = on
@@ -27,14 +24,15 @@ Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
 Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
 Beams:sigmaVertexZ = 0.30      !  0.30 mm
 
-! 4) Hard process : qq, at 365 GeV
-Beams:eCM = 91.188               ! CM energy of collision
-WeakSingleBoson:ffbar2ffbar(s:gmZ) = on
+! 3) Hard process : ttbar pair production at 100TeV
+Beams:eCM = 125  ! CM energy of collision
+HiggsSM:ffbar2H = on
 
+! 4) Settings for the event generation process in the Pythia8 library.
 PartonLevel:ISR = on               ! initial-state radiation
 PartonLevel:FSR = on               ! final-state radiation
 
-! Decays
-!Z0
-23:onMode = off
-23:onIfAny = 1 2 3 4 5 6
+! 5) Non-standard settings; exemplifies tuning possibilities.
+25:m0       = 125.0               ! Higgs mass
+25:onMode   = off
+25:onIfAny  = 4

--- a/FCCee/Generator/Pythia8/p8_noBES_ee_H_Hgg_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_noBES_ee_H_Hgg_ecm125.cmd
@@ -1,25 +1,22 @@
 Random:setSeed = on
-Main:numberOfEvents = 1000         ! number of events to generate
 Main:timesAllowErrors = 5          ! how many aborts before run stops
-
+PDF:lepton = on
 
 ! 2) Settings related to output in init(), next() and stat().
 Init:showChangedSettings = on      ! list changed settings
 Init:showChangedParticleData = off ! list changed particle data
-Next:numberCount = 100            ! print message every n events
+Next:numberCount = 100             ! print message every n events
 Next:numberShowInfo = 1            ! print event information n times
 Next:numberShowProcess = 1         ! print process record n times
 Next:numberShowEvent = 0           ! print event record n times
-Stat:showPartonLevel = off
 
-! 3) Beam parameter settings. Values below agree with default ones.
-Beams:idA = 11                   ! first beam, e- = 11
-Beams:idB = -11                  ! second beam, e+ = -11
+Beams:idA = 11                   ! first beam, e+ = 11
+Beams:idB = -11                   ! second beam, e- = -11
 
-! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
-Beams:allowMomentumSpread  = on
-Beams:sigmaPzA = 0.0602
-Beams:sigmaPzB = 0.0602
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = off
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
 
 ! Vertex smearing :
 Beams:allowVertexSpread = on
@@ -27,14 +24,16 @@ Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
 Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
 Beams:sigmaVertexZ = 0.30      !  0.30 mm
 
-! 4) Hard process : qq, at 365 GeV
-Beams:eCM = 91.188               ! CM energy of collision
-WeakSingleBoson:ffbar2ffbar(s:gmZ) = on
 
+! 3) Hard process : ttbar pair production at 100TeV
+Beams:eCM = 125  ! CM energy of collision
+HiggsSM:ffbar2H = on
+
+! 4) Settings for the event generation process in the Pythia8 library.
 PartonLevel:ISR = on               ! initial-state radiation
 PartonLevel:FSR = on               ! final-state radiation
 
-! Decays
-!Z0
-23:onMode = off
-23:onIfAny = 1 2 3 4 5 6
+! 5) Non-standard settings; exemplifies tuning possibilities.
+25:m0       = 125.0               ! Higgs mass
+25:onMode   = off
+25:onIfAny  = 21

--- a/FCCee/Generator/Pythia8/p8_noBES_ee_H_Htautau_ecm125.cmd
+++ b/FCCee/Generator/Pythia8/p8_noBES_ee_H_Htautau_ecm125.cmd
@@ -1,25 +1,22 @@
 Random:setSeed = on
-Main:numberOfEvents = 1000         ! number of events to generate
 Main:timesAllowErrors = 5          ! how many aborts before run stops
-
+PDF:lepton = on
 
 ! 2) Settings related to output in init(), next() and stat().
 Init:showChangedSettings = on      ! list changed settings
 Init:showChangedParticleData = off ! list changed particle data
-Next:numberCount = 100            ! print message every n events
+Next:numberCount = 100             ! print message every n events
 Next:numberShowInfo = 1            ! print event information n times
 Next:numberShowProcess = 1         ! print process record n times
 Next:numberShowEvent = 0           ! print event record n times
-Stat:showPartonLevel = off
 
-! 3) Beam parameter settings. Values below agree with default ones.
-Beams:idA = 11                   ! first beam, e- = 11
-Beams:idB = -11                  ! second beam, e+ = -11
+Beams:idA = 11                   ! first beam, e+ = 11
+Beams:idB = -11                   ! second beam, e- = -11
 
-! Beam energy spread: 0.132% x 45.594 GeV = 0.0602 GeV
-Beams:allowMomentumSpread  = on
-Beams:sigmaPzA = 0.0602
-Beams:sigmaPzB = 0.0602
+! Beam energy spread: 0.132% x 62.5 GeV = 0.0825 GeV
+Beams:allowMomentumSpread  = off
+Beams:sigmaPzA = 0.0825
+Beams:sigmaPzB = 0.0825
 
 ! Vertex smearing :
 Beams:allowVertexSpread = on
@@ -27,14 +24,16 @@ Beams:sigmaVertexX = 4.50e-3   !  6.4 mum / sqrt2
 Beams:sigmaVertexY = 20.0E-6   !  28.3 nm / sqrt2
 Beams:sigmaVertexZ = 0.30      !  0.30 mm
 
-! 4) Hard process : qq, at 365 GeV
-Beams:eCM = 91.188               ! CM energy of collision
-WeakSingleBoson:ffbar2ffbar(s:gmZ) = on
 
+! 3) Hard process : ttbar pair production at 100TeV
+Beams:eCM = 125  ! CM energy of collision
+HiggsSM:ffbar2H = on
+
+! 4) Settings for the event generation process in the Pythia8 library.
 PartonLevel:ISR = on               ! initial-state radiation
 PartonLevel:FSR = on               ! final-state radiation
 
-! Decays
-!Z0
-23:onMode = off
-23:onIfAny = 1 2 3 4 5 6
+! 5) Non-standard settings; exemplifies tuning possibilities.
+25:m0       = 125.0               ! Higgs mass
+25:onMode   = off
+25:onIfAny  = 15


### PR DESCRIPTION
… the P8 generation is by far too inefficient).

And updated the remaining P8 cards at the Z peak.