### PR TITLE
qqH signal at 240 GeV, nunuZ & egamma/gammae/gammagamma to ee/mumu/tautau

### DIFF
--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_nuenueZ_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_nuenueZ_ecm240.sin
@@ -1,0 +1,62 @@
+########################################################################
+#
+# Whizard 3.0.3
+#
+# e e -> nue \bar{nue} Z
+#
+# W-exchange diagrams only, otherwise double-counting with inclusive ZZ.
+#
+# Careful: the Z is produced on-shell.
+# If, instead, a 2 -> 4 process is generated, one can not select only the
+# W-exchange diagrams. Will have to move to a proper 4f generation at some point.
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = e1, E1 => n1, N1, Z  { $restrictions = "!Z" }
+
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+gaussian_spread1 = 0.185%
+gaussian_spread2 = 0.185%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_qqH_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_qqH_ecm240.sin
@@ -1,0 +1,62 @@
+########################################################################
+#
+# Whizard 3.0.3
+#
+# e e -> mu mu H   (only one diagram, e e -> Z H and Z -> mumu )
+#
+# Hadronisation by Pythia6. Inclusive H decays (by Pythia)
+#
+########################################################################
+#
+
+model = SM
+
+mH     = 125 GeV
+
+# Center of mass energy
+sqrts = 240 GeV
+
+alias q = u:d:s:c:b
+alias qbar = ubar:dbar:sbar:cbar:bbar
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = e1, E1 => q, qbar, H
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    # do not use this option, makes Pythia crash
+?keep_remnants = true
+
+gaussian_spread1 = 0.185%
+gaussian_spread2 = 0.185%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.1; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1;  MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_egamma_eZ_Zee_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_egamma_eZ_Zee_ecm240.sin
@@ -1,0 +1,63 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# e gamma ->  e Z  -> e mu mu  in EPA approximation
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = e1, A => e1, e1, E1  {$restrictions = "4+5~Z "}
+
+beams = e1, E1 => gaussian => isr, epa
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 240.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+gaussian_spread1 = 0.185%
+gaussian_spread2 = 0.185%
+
+!   cuts = all M > 100 GeV [ e1, E1 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_egamma_eZ_Zmumu_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_egamma_eZ_Zmumu_ecm240.sin
@@ -1,0 +1,63 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# e gamma ->  e Z  -> e mu mu  in EPA approximation
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = e1, A => e1, e2,E2  {$restrictions = "4+5~Z "}
+
+beams = e1, E1 => gaussian => isr, epa
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 240.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+gaussian_spread1 = 0.185%
+gaussian_spread2 = 0.185%
+
+!   cuts = all M > 100 GeV [ e1, E1 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_gaga_ee_60_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_gaga_ee_60_ecm240.sin
@@ -1,0 +1,62 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# gamma gamma ->  mu mu  (EPA approximation)
+#   M( mu mu ) > 60 GeV
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = A, A => e1,E1  
+
+beams = e1, E1 => epa, epa
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 4.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+
+cuts = all M > 60 GeV [ e1, E1 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_gaga_mumu_60_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_gaga_mumu_60_ecm240.sin
@@ -1,0 +1,62 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# gamma gamma ->  mu mu  (EPA approximation)
+#   M( mu mu ) > 60 GeV
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = A, A => e2,E2  
+
+beams = e1, E1 => epa, epa
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 4.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+
+cuts = all M > 60 GeV [ e2, E2 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_gaga_tautau_60_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_gaga_tautau_60_ecm240.sin
@@ -1,0 +1,62 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# gamma gamma ->  tau tau  (EPA approximation)
+#   M( tau tau ) > 60 GeV
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = A, A => e3, E3
+
+beams = e1, E1 => epa, epa
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 4.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+
+cuts = all M > 60 GeV [ e3, E3 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_gammae_eZ_Zee_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_gammae_eZ_Zee_ecm240.sin
@@ -1,0 +1,63 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# e gamma ->  e Z  -> e mu mu  in EPA approximation
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = A, E1 => E1, e1,E1  {$restrictions = "4+5~Z "}
+
+beams = e1, E1 => gaussian => epa, isr
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 240.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+gaussian_spread1 = 0.185%
+gaussian_spread2 = 0.185%
+
+!   cuts = all M > 100 GeV [ e1, E1 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_gammae_eZ_Zmumu_ecm240.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_gammae_eZ_Zmumu_ecm240.sin
@@ -1,0 +1,63 @@
+########################################################################
+#
+# Whizard 2.8.5
+#
+# e gamma ->  e Z  -> e mu mu  in EPA approximation
+#
+# Hadronisation by Pythia6. 
+#
+########################################################################
+#
+
+model = SM
+
+# Center of mass energy
+sqrts = 240 GeV
+
+# Processes
+
+#?vis_diags = true
+
+
+process proc = A, E1 => E1, e2,E2  {$restrictions = "4+5~Z "}
+
+beams = e1, E1 => gaussian => epa, isr
+?keep_beams  = true    
+?keep_remnants = true
+
+$epa_mode = "default"
+epa_alpha          = 0.0072993
+epa_mass           = me
+epa_q_max          = 240.
+epa_x_min          = 0.01
+!isr_order         = 3
+! ?isr_handler       = true
+! $isr_handler_mode  = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = me
+
+gaussian_spread1 = 0.185%
+gaussian_spread2 = 0.185%
+
+!   cuts = all M > 100 GeV [ e1, E1 ]
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0098; PARP(152)=2.54e-5; PARP(153)=0.646; PARP(154)=1.937; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 5:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+simulate (proc) {checkpoint = 100}
+


### PR DESCRIPTION
Naive doubt on the gammagamma cards: BES was not included in the v2.8.5 cards. Is it on purpose?