### PR TITLE
Add two cards for charge conjugated Bd to Ds Ds K* decays

### DIFF
--- a/FCCee/Generator/EvtGen/Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0_ChargeConjugation.dec
+++ b/FCCee/Generator/EvtGen/Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0_ChargeConjugation.dec
@@ -1,0 +1,98 @@
+# NickName: Bd_DsDsKst0,Kpi,Ds_TauNu,Ds_pipipipi0pi0
+# This is the charge conjugation of the Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0.dec
+# Only tau- is produced in this process
+# Descriptor: [B0 -> (Ds- -> (tau- ->  pi+  pi-  pi- nu_tau) anti-nu_tau) (Ds+ -> (eta0 / omega0 -> pi+ pi- pi0)  pi+ pi0) (K*0 -> K+ pi-)]cc
+#
+# Documentation:  K*0 forced to K+ pi-, Ds forced to tau nu or 3pi2pi0 (via eta0/omega0)
+# Decay file for B0 -> Ds+ Ds- K*0
+# EndDocumentation
+# 
+# Date:   20210913
+# Responsible: Stephane Monteil
+# Email: monteil@in2p3.fr
+Alias Bd_SIGNAL     B0
+Alias Bdbar_SIGNAL  anti-B0
+ChargeConj Bd_SIGNAL Bdbar_SIGNAL
+
+Alias MyDs+    D_s+
+Alias MyDs-    D_s-
+Alias MyK*0    K*0
+Alias Myanti-K*0    anti-K*0
+Alias MyTau+ tau+
+Alias MyTau- tau-
+Alias Mypi0    pi0
+Alias Myeta0    eta
+Alias Myomega0    omega
+ChargeConj Mypi0     Mypi0
+ChargeConj MyDs+   MyDs- 
+ChargeConj MyK*0  Myanti-K*0
+ChargeConj MyTau+  MyTau-
+ChargeConj Myeta0     Myeta0
+ChargeConj Myomega0     Myomega0
+
+#----------------
+# Decay of the B0
+#----------------
+Decay Bd_SIGNAL
+  1.000 MyDs+ MyDs- MyK*0 PHSP;
+Enddecay
+CDecay Bdbar_SIGNAL
+
+
+# -----------------
+# Decay of the Ds-
+# -----------------
+Decay MyDs-
+  1.000 MyTau- anti-nu_tau   SLN;
+Enddecay
+
+# -----------------
+# Decay of the Ds+
+# -----------------
+
+Decay MyDs+
+  0.467 Myeta0 pi+ pi0  PHSP;
+  0.533 Myomega0 pi+ pi0  PHSP;
+Enddecay
+
+# -----------------
+# Decay of the eta0
+# -----------------
+
+Decay Myeta0
+  1.000 pi+ pi- pi0 PHSP;
+Enddecay
+
+# -----------------
+# Decay of the omega0
+# -----------------
+
+Decay Myomega0
+  1.000 pi+ pi- pi0 OMEGA_DALITZ;
+Enddecay
+# -----------------
+# Decay of the K*0 anti-K*0
+# -----------------
+#
+Decay MyK*0
+  1.000 K+ pi-  VSS;
+Enddecay
+CDecay Myanti-K*0
+
+#-----------
+# Decay of the pi0
+#-----------
+Decay Mypi0
+  1.000 gamma   gamma  PHSP;
+Enddecay
+
+# -----------------
+# Decay of the tau+-
+# -----------------
+#  
+Decay MyTau-
+  1.00      pi-     pi-      pi+     nu_tau                TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4;
+Enddecay
+CDecay MyTau+
+#
+End

--- a/FCCee/Generator/EvtGen/Bd2DsDsKstarDs2TaunuDs2pipipipi0v2_ChargeConjugation.dec
+++ b/FCCee/Generator/EvtGen/Bd2DsDsKstarDs2TaunuDs2pipipipi0v2_ChargeConjugation.dec
@@ -1,0 +1,98 @@
+# NickName: Bd_DsDsKst0,Kpi,Ds_TauNu,Ds_pipipipi0
+# This is the charge conjugation of the Bd2DsDsKstarDs2TaunuDs2pipipipi0v2.dec
+# Only tau- is produced in this process
+# Descriptor: [B0 -> (Ds- -> (tau- ->  pi+  pi-  pi- nu_tau) anti-nu_tau) (Ds+ -> (eta0 / omega0 -> pi+ pi- pi0)  pi+) (K*0 -> K+ pi-)]cc
+#
+# Documentation:  K*0 forced to K+ pi-, Ds forced to tau nu or 3pi1pi0 (via eta0/omega0)
+# Decay file for B0 -> Ds+ Ds- K*0
+# EndDocumentation
+# 
+# Date:   20210913
+# Responsible: Stephane Monteil
+# Email: monteil@in2p3.fr
+Alias Bd_SIGNAL     B0
+Alias Bdbar_SIGNAL  anti-B0
+ChargeConj Bd_SIGNAL Bdbar_SIGNAL
+
+Alias MyDs+    D_s+
+Alias MyDs-    D_s-
+Alias MyK*0    K*0
+Alias Myanti-K*0    anti-K*0
+Alias MyTau+ tau+
+Alias MyTau- tau-
+Alias Mypi0    pi0
+Alias Myeta0    eta
+Alias Myomega0    omega
+ChargeConj Mypi0     Mypi0
+ChargeConj MyDs+   MyDs- 
+ChargeConj MyK*0  Myanti-K*0
+ChargeConj MyTau+  MyTau-
+ChargeConj Myeta0     Myeta0
+ChargeConj Myomega0     Myomega0
+
+#----------------
+# Decay of the B0
+#----------------
+Decay Bd_SIGNAL
+  1.000 MyDs+ MyDs- MyK*0 PHSP;
+Enddecay
+CDecay Bdbar_SIGNAL
+
+
+# -----------------
+# Decay of the Ds-
+# -----------------
+Decay MyDs-
+  1.000 MyTau- anti-nu_tau   SLN;
+Enddecay
+
+# -----------------
+# Decay of the Ds+
+# -----------------
+
+Decay MyDs+
+  0.693 Myeta0 pi+ PHSP;
+  0.307 Myomega0 pi+ PHSP;
+Enddecay
+
+# -----------------
+# Decay of the eta0
+# -----------------
+
+Decay Myeta0
+  1.000 pi+ pi- pi0 PHSP;
+Enddecay
+
+# -----------------
+# Decay of the omega0
+# -----------------
+
+Decay Myomega0
+  1.000 pi+ pi- pi0 OMEGA_DALITZ;
+Enddecay
+# -----------------
+# Decay of the K*0 anti-K*0
+# -----------------
+#
+Decay MyK*0
+  1.000 K+ pi-  VSS;
+Enddecay
+CDecay Myanti-K*0
+
+#-----------
+# Decay of the pi0
+#-----------
+Decay Mypi0
+  1.000 gamma   gamma  PHSP;
+Enddecay
+
+# -----------------
+# Decay of the tau+-
+# -----------------
+#  
+Decay MyTau-
+  1.00      pi-     pi-      pi+     nu_tau                TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4;
+Enddecay
+CDecay MyTau+
+#
+End


### PR DESCRIPTION
Two of the current cards involve B0 -> Ds+ Ds- K* decays where the Ds+ and Ds- are decayed differently:
[Bd2DsDsKstarDs2TaunuDs2pipipipi0v2](https://github.com/HEP-FCC/FCC-config/blob/winter2023/FCCee/Generator/EvtGen/Bd2DsDsKstarDs2TaunuDs2pipipipi0v2.dec) and [Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0](https://github.com/HEP-FCC/FCC-config/blob/winter2023/FCCee/Generator/EvtGen/Bd2DsDsKstarDs2TaunuDs2pipipipi0pi0.dec).
Due to the syntax of EvtGen, in these process, the Ds+ always decay to taus while the Ds- always decay to hadrons, regardless of the charge conjugation of B0 and anti-B0.

Two cards are added to cover the charge conjugated decay, where the Ds+ decays to hadrons and Ds- to taus.

These processes are intended for the B0 -> K tau tau analysis. Cards are tested locally.