### PR TITLE
Add cards including t -> W s decays

### DIFF
--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWs_pol_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWs_pol_ecm365.sin
@@ -1,0 +1,107 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV, t+ -> W+ b, t- -> W- sbar. Polarization kept, CKM enabled
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Processes
+
+
+process proc = e1, E1 => t, tbar
+process t_dec = t => Wp, b
+process tbar_dec = T => Wm, S  # cannot name it "T_dec", which conflicts with the previous line "t_dec". Seems some internal compilation is case-insensitive.
+process Wp_en = Wp => E1, n1
+process Wp_mn = Wp => E2, n2
+process Wp_tn = Wp => E3, n3
+process Wp_ud = Wp => u, D
+process Wp_us = Wp => u, S
+process Wp_ub = Wp => u, B
+process Wp_cd = Wp => c, D
+process Wp_cs = Wp => c, S
+process Wp_cb = Wp => c, B
+
+process Wm_en = Wm => e1, N1
+process Wm_mn = Wm => e2, N2
+process Wm_tn = Wm => e3, N3
+process Wm_ud = Wm => U, d
+process Wm_us = Wm => U, s
+process Wm_ub = Wm => U, b
+process Wm_cd = Wm => C, d
+process Wm_cs = Wm => C, s
+process Wm_cb = Wm => C, b
+
+polarized t, T, Wp, Wm
+
+unstable t (t_dec)
+unstable T (tbar_dec)
+unstable Wp (Wp_en, Wp_mn, Wp_tn, Wp_ud, Wp_us, Wp_ub, Wp_cd, Wp_cs, Wp_cb)
+unstable Wm (Wm_en, Wm_mn, Wm_tn, Wm_ud, Wm_us, Wm_ub, Wm_cd, Wm_cs, Wm_cb)
+
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWsTWb_pol_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWsTWb_pol_ecm365.sin
@@ -1,0 +1,107 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV, t+ -> W+ s, t- -> W- bbar. Polarization kept, CKM enabled
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Processes
+
+
+process proc = e1, E1 => t, tbar
+process t_dec = t => Wp, s
+process tbar_dec = T => Wm, B  # cannot name it "T_dec", which conflicts with the previous line "t_dec". Seems some internal compilation is case-insensitive.
+process Wp_en = Wp => E1, n1
+process Wp_mn = Wp => E2, n2
+process Wp_tn = Wp => E3, n3
+process Wp_ud = Wp => u, D
+process Wp_us = Wp => u, S
+process Wp_ub = Wp => u, B
+process Wp_cd = Wp => c, D
+process Wp_cs = Wp => c, S
+process Wp_cb = Wp => c, B
+
+process Wm_en = Wm => e1, N1
+process Wm_mn = Wm => e2, N2
+process Wm_tn = Wm => e3, N3
+process Wm_ud = Wm => U, d
+process Wm_us = Wm => U, s
+process Wm_ub = Wm => U, b
+process Wm_cd = Wm => C, d
+process Wm_cs = Wm => C, s
+process Wm_cb = Wm => C, b
+
+polarized t, T, Wp, Wm
+
+unstable t (t_dec)
+unstable T (tbar_dec)
+unstable Wp (Wp_en, Wp_mn, Wp_tn, Wp_ud, Wp_us, Wp_ub, Wp_cd, Wp_cs, Wp_cb)
+unstable Wm (Wm_en, Wm_mn, Wm_tn, Wm_ud, Wm_us, Wm_ub, Wm_cd, Wm_cs, Wm_cb)
+
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+


### PR DESCRIPTION
These two cards are for a preliminary study of measuring |Vts| with tt events.
The CKM is enabled in these cards, so the top quark can decay into W + s. 
One card has t -> W+ s, tbar -> W- bbar
The other has t -> W+ b, tbar -> W- sbar 
W is decayed inclusively.