### PR TITLE
fix small text parsing issue in Bs to lep cards

### DIFF
--- a/FCCee/Generator/EvtGen/Bs2EE.dec
+++ b/FCCee/Generator/EvtGen/Bs2EE.dec
@@ -3,7 +3,7 @@ Alias   Bsbar_SIGNAL    anti-B_s0
 ChargeConj Bs_SIGNAL  Bsbar_SIGNAL
 
 Decay Bs_SIGNAL
-  1.0    e+      e-         PHSP;
+  1.0    e+      e-         PHSP;
 Enddecay
 CDecay Bsbar_SIGNAL
 

--- a/FCCee/Generator/EvtGen/Bs2MuMu.dec
+++ b/FCCee/Generator/EvtGen/Bs2MuMu.dec
@@ -3,7 +3,7 @@ Alias   Bsbar_SIGNAL    anti-B_s0
 ChargeConj Bs_SIGNAL  Bsbar_SIGNAL
 
 Decay Bs_SIGNAL
-  1.0    mu+      mu-         PHSP;
+  1.0    mu+      mu-         PHSP;
 Enddecay
 CDecay Bsbar_SIGNAL
 

--- a/FCCee/Generator/EvtGen/Bs2NuNu.dec
+++ b/FCCee/Generator/EvtGen/Bs2NuNu.dec
@@ -3,7 +3,7 @@ Alias   Bsbar_SIGNAL    anti-B_s0
 ChargeConj Bs_SIGNAL  Bsbar_SIGNAL
 
 Decay Bs_SIGNAL
-  1.0    nu_e      anti-nu_e         PHSP;
+  1.0    nu_e       anti-nu_e         PHSP;
 Enddecay
 CDecay Bsbar_SIGNAL
 


### PR DESCRIPTION
Somehow the space in the cards were not parsed correctly, shown as `   �| �|  ` on lxplus.
Probably because the tab in that line was a special character, which was not recognized by ASCII parser?
In any case, this PR should fix it.