### PR TITLE
Add back alias of B hadrons

### DIFF
--- a/FCCee/Generator/EvtGen/Bd2KstEE.dec
+++ b/FCCee/Generator/EvtGen/Bd2KstEE.dec
@@ -1,11 +1,14 @@
+Alias       Bd_SIGNAL     B0
+Alias       Bdbar_SIGNAL  anti-B0
+ChargeConj  Bd_SIGNAL     Bdbar_SIGNAL
 Alias      MyK*0      K*0
 Alias      Myanti-K*0 anti-K*0
 ChargeConj MyK*0      Myanti-K*0
 #
-Decay B0
+Decay Bd_SIGNAL
   1.000        MyK*0    e+    e-           BTOSLLBALL;
 Enddecay
-CDecay anti-B0
+CDecay Bdbar_SIGNAL
 #
 Decay MyK*0
   1.000        K+       pi-              VSS;

--- a/FCCee/Generator/EvtGen/Bd2KstTauTau.dec
+++ b/FCCee/Generator/EvtGen/Bd2KstTauTau.dec
@@ -1,3 +1,6 @@
+Alias       Bd_SIGNAL     B0
+Alias       Bdbar_SIGNAL  anti-B0
+ChargeConj  Bd_SIGNAL     Bdbar_SIGNAL
 # Tauola steering options
 Define TauolaCurrentOption 0
 Define TauolaBR1 1.0
@@ -9,10 +12,10 @@ Alias         MyK*0      K*0
 Alias         Myanti-K*0 anti-K*0
 ChargeConj    MyK*0      Myanti-K*0
 #
-Decay B0
+Decay Bd_SIGNAL
   1.000       MyK*0      Mytau+    Mytau-       BTOSLLBALL;
 Enddecay
-CDecay anti-B0
+CDecay Bdbar_SIGNAL
 #
 Decay MyK*0
   1.000       K+         pi-       VSS;

--- a/FCCee/Generator/EvtGen/Bs2TauTau.dec
+++ b/FCCee/Generator/EvtGen/Bs2TauTau.dec
@@ -1,3 +1,6 @@
+Alias   Bs_SIGNAL   B_s0
+Alias   Bsbar_SIGNAL    anti-B_s0
+ChargeConj Bs_SIGNAL  Bsbar_SIGNAL
 # Tauola steering options
 Define TauolaCurrentOption 0
 Define TauolaBR1 1.0
@@ -6,10 +9,10 @@ Alias         Mytau+     tau+
 Alias         Mytau-     tau-
 ChargeConj    Mytau+     Mytau-
 #
-Decay B_s0
+Decay Bs_SIGNAL
   1.000       Mytau+    Mytau-       PHSP;
 Enddecay
-CDecay anti-B_s0
+CDecay Bsbar_SIGNAL
 #
 Decay Mytau-
   1.00        TAUOLA 5;

--- a/FCCee/Generator/EvtGen/Bs2TauTauTAUHADNU.dec
+++ b/FCCee/Generator/EvtGen/Bs2TauTauTAUHADNU.dec
@@ -1,3 +1,6 @@
+Alias   Bs_SIGNAL   B_s0
+Alias   Bsbar_SIGNAL    anti-B_s0
+ChargeConj Bs_SIGNAL  Bsbar_SIGNAL
 # Tauola steering options
 Define TauolaCurrentOption 0
 Define TauolaBR1 1.0
@@ -6,10 +9,10 @@ Alias         Mytau+     tau+
 Alias         Mytau-     tau-
 ChargeConj    Mytau+     Mytau-
 #
-Decay B_s0
+Decay Bs_SIGNAL
   1.000       Mytau+    Mytau-       PHSP;
 Enddecay
-CDecay anti-B_s0
+CDecay Bsbar_SIGNAL
 #
 Decay Mytau-
   1.00        pi-     pi-     pi+     nu_tau                  TAUHADNU -0.108 0.775 0.149 1.364 0.400 1.23 0.4;


### PR DESCRIPTION
Alias of initial hadrons is necessary (because of the way the job scripts are written).
It is missing in a few cards. Adding them back.