### PR TITLE
add flag in photonID parameters

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -421,7 +421,7 @@ if doSWClustering:
                                                    layerFieldNames=["layer"],
                                                    thetaRecalcWeights=[ecalBarrelThetaWeights],
                                                    do_photon_shapeVar=runPhotonIDTool,
-                                                   do_widthTheta_logE_weights=logEWeightInPhotonID
+                                                   do_widthTheta_logE_weights=logEWeightInPhotonID,
                                                    OutputLevel=INFO
                                                    )
 
@@ -559,7 +559,7 @@ if doTopoClustering:
                                                        layerFieldNames=["layer"],
                                                        thetaRecalcWeights=[ecalBarrelThetaWeights],
                                                        do_photon_shapeVar=runPhotonIDTool,
-                                                       do_widthTheta_logE_weights=logEWeightInPhotonID
+                                                       do_widthTheta_logE_weights=logEWeightInPhotonID,
                                                        OutputLevel=INFO)
 
     if applyMVAClusterEnergyCalibration:

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -98,6 +98,7 @@ ecalBarrelThetaWeights = [-1, 3.0, 3.0, 3.0, 4.25, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0]
 
 # run photon ID algorithm
 runPhotonIDTool = False
+logEWeightInPhotonID = False and runPhotonIDTool
 
 #
 # ALGORITHMS AND SERVICES SETUP
@@ -419,6 +420,7 @@ if doSWClustering:
                                                    layerFieldNames=["layer"],
                                                    thetaRecalcWeights=[ecalBarrelThetaWeights],
                                                    do_photon_shapeVar=runPhotonIDTool,
+                                                   do_widthTheta_logE_weights=logEWeightInPhotonID
                                                    OutputLevel=INFO
                                                    )
 
@@ -555,6 +557,7 @@ if doTopoClustering:
                                                        layerFieldNames=["layer"],
                                                        thetaRecalcWeights=[ecalBarrelThetaWeights],
                                                        do_photon_shapeVar=runPhotonIDTool,
+                                                       do_widthTheta_logE_weights=logEWeightInPhotonID
                                                        OutputLevel=INFO)
 
     if applyMVAClusterEnergyCalibration:

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -99,7 +99,7 @@ ecalBarrelThetaWeights = [-1, 3.0, 3.0, 3.0, 4.25, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0]
 
 # run photon ID algorithm
 runPhotonIDTool = False
-logEWeightInPhotonID = False and runPhotonIDTool
+logEWeightInPhotonID = False
 
 #
 # ALGORITHMS AND SERVICES SETUP


### PR DESCRIPTION
Follow-up of https://github.com/HEP-FCC/k4RecCalorimeter/pull/79/ .
Added the flag in photon ID parameters, to calculate variables using log E weights instead of linear E weights.

Tagging @giovannimarchiori  @BrieucF 

Cheers, Tong