### PR TITLE
Enable noise for ALLEGRO ECAL barrel cells

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -55,7 +55,7 @@ from math import cos, sin, tan
 #
 inputfile = "ALLEGRO_sim.root"  # input file produced with ddsim
 Nevts = -1                      # -1 means all events
-addNoise = True                # add noise or not to the cell energy
+addNoise = False                # add noise or not to the cell energy
 dumpGDML = False                # create GDML file of detector model
 runHCal = False                  # simulate only the ECAL or both ECAL+HCAL
 

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -91,7 +91,7 @@ applyUpDownstreamCorrections = False and not runHCal
 
 # BDT regression from total cluster energy and fraction of energy in each layer (after correction for sampling fraction)
 # not to be applied (yet) for ECAL+HCAL clustering (MVA trained only on ECAL so far)
-applyMVAClusterEnergyCalibration = False and not runHCal # temporarily switched off due to negative cell signals introduced by noise
+applyMVAClusterEnergyCalibration = True and not runHCal and not addNoise # temporarily switched off due to negative cell signals introduced by noise
 
 # calculate cluster energy and barycenter per layer and save it as extra parameters
 addShapeParameters = True and not runHCal

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -271,6 +271,7 @@ createEcalEndcapPositionedCells.positionedHits.Path = ecalEndcapPositionedCellsN
 
 
 if addNoise:
+    #FIXME Input histograms need to be updated to match the new detector geometry of ALLEGRO v3
     ecalBarrelNoisePath = "elecNoise_ecalBarrelFCCee_theta.root"
     ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
     from Configurables import NoiseCaloCellsVsThetaFromFileTool


### PR DESCRIPTION
The full simulation of ALLEGRO can be performed with noise on ECAL barrel cells.
1. PR to be merged only after https://github.com/HEP-FCC/k4RecCalorimeter/pull/107
2. The MVA calibration is temporarily switched off due to the negative input brought by the noise.
3. Noise filter is not yet available. The size of output file of run_digi_reco.py increases by two orders of magnitude!
4. A FIXME comment is added on input histograms for noise. The input needs to be re-calculated using the latest ALLEGRO geometry.