### PR TITLE
Update to IDEA_o1_v03 vertex

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -66,6 +66,37 @@ vtxd_digitizer  = VTXdigitizer("VTXDdigitizer",
     OutputLevel = INFO
 )
 
+# digitise silicon wrapper hits
+siWrapperResolution_x   = 0.050/math.sqrt(12) # [mm]
+siWrapperResolution_y   = 1.0/math.sqrt(12) # [mm]
+siWrapperResolution_t   = 0.040 # [ns], assume 40 ps timing resolution for a single layer -> Should lead to <30 ps resolution when >1 hit
+
+siwrb_digitizer = VTXdigitizer("SiWrBdigitizer",
+    inputSimHits = "SiWrBCollection",
+    outputDigiHits = "SiWrBDigis",
+    outputSimDigiAssociation = "SiWrBSimDigiLinks",
+    detectorName = "SiWrB",
+    readoutName = "SiWrBCollection",
+    xResolution = [siWrapperResolution_x, siWrapperResolution_x], # mm, r-phi direction
+    yResolution = [siWrapperResolution_y, siWrapperResolution_y], # mm, z direction
+    tResolution = [siWrapperResolution_t, siWrapperResolution_t],
+    forceHitsOntoSurface = False,
+    OutputLevel = INFO
+)
+
+siwrd_digitizer = VTXdigitizer("SiWrDdigitizer",
+    inputSimHits = "SiWrDCollection",
+    outputDigiHits = "SiWrDDigis",
+    outputSimDigiAssociation = "SiWrDSimDigiLinks",
+    detectorName = "SiWrD",
+    readoutName = "SiWrDCollection",
+    xResolution = [siWrapperResolution_x, siWrapperResolution_x], # mm, r-phi direction
+    yResolution = [siWrapperResolution_y, siWrapperResolution_y], # mm, z direction
+    tResolution = [siWrapperResolution_t, siWrapperResolution_t],
+    forceHitsOntoSurface = False,
+    OutputLevel = INFO
+)
+
 # digitize drift chamber hits, waiting to merge the digitizer for the new drift chamber
 #from Configurables import DCHsimpleDigitizerExtendedEdm
 #dch_digitizer = DCHsimpleDigitizerExtendedEdm("DCHsimpleDigitizerExtendedEdm",
@@ -119,6 +150,8 @@ application_mgr = ApplicationMgr(
 			  inp,
               vtxb_digitizer,
               vtxd_digitizer,
+              siwrb_digitizer,
+              siwrd_digitizer,
               #dch_digitizer,
               tracksFromGenParticles, 
               plotTrackDCHHitDistances,

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -33,8 +33,8 @@ geoservice.OutputLevel = INFO
 # digitize vertex hits
 from Configurables import VTXdigitizer
 import math
-innerVertexResolution_x = 0.003 # [mm], assume 5 µm resolution for ARCADIA sensor
-innerVertexResolution_y = 0.003 # [mm], assume 5 µm resolution for ARCADIA sensor
+innerVertexResolution_x = 0.003 # [mm], assume 3 µm resolution for ARCADIA sensor
+innerVertexResolution_y = 0.003 # [mm], assume 3 µm resolution for ARCADIA sensor
 innerVertexResolution_t = 1000 # [ns]
 outerVertexResolution_x = 0.050/math.sqrt(12) # [mm], assume ATLASPix3 sensor with 50 µm pitch
 outerVertexResolution_y = 0.150/math.sqrt(12) # [mm], assume ATLASPix3 sensor with 150 µm pitch

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -40,41 +40,28 @@ outerVertexResolution_x = 0.050/math.sqrt(12) # [mm], assume ATLASPix3 sensor wi
 outerVertexResolution_y = 0.150/math.sqrt(12) # [mm], assume ATLASPix3 sensor with 150 µm pitch
 outerVertexResolution_t = 1000 # [ns]
 
-vtxib_digitizer = VTXdigitizer("VTXIBdigitizer",
-    inputSimHits = "VTXIBCollection",
-    outputDigiHits = "VTXIBDigis",
-    outputSimDigiAssociation = "VTXIBSimDigiLinks",
+vtxb_digitizer = VTXdigitizer("VTXBdigitizer",
+    inputSimHits = "VertexBarrelCollection",
+    outputDigiHits = "VTXBDigis",
+    outputSimDigiAssociation = "VTXBSimDigiLinks",
     detectorName = "Vertex",
-    readoutName = "VTXIBCollection",
-    xResolution = innerVertexResolution_x, # mm, r-phi direction
-    yResolution = innerVertexResolution_y, # mm, z direction
-    tResolution = innerVertexResolution_t,
-    forceHitsOntoSurface = False,
-    OutputLevel = INFO
-)
-
-vtxob_digitizer = VTXdigitizer("VTXOBdigitizer",
-    inputSimHits = "VTXOBCollection",
-    outputDigiHits = "VTXOBDigis",
-    outputSimDigiAssociation = "VTXOBSimDigiLinks",
-    detectorName = "Vertex",
-    readoutName = "VTXOBCollection",
-    xResolution = outerVertexResolution_x, # mm, r-phi direction
-    yResolution = outerVertexResolution_y, # mm, z direction
-    tResolution = outerVertexResolution_t, # ns
+    readoutName = "VertexBarrelCollection",
+    xResolution = [innerVertexResolution_x, innerVertexResolution_x, innerVertexResolution_x, outerVertexResolution_x, outerVertexResolution_x], # mm, r-phi direction
+    yResolution = [innerVertexResolution_y, innerVertexResolution_y, innerVertexResolution_y, outerVertexResolution_y, outerVertexResolution_y], # mm, z direction
+    tResolution = [innerVertexResolution_t, innerVertexResolution_t, innerVertexResolution_t, outerVertexResolution_t, outerVertexResolution_t],
     forceHitsOntoSurface = False,
     OutputLevel = INFO
 )
 
 vtxd_digitizer  = VTXdigitizer("VTXDdigitizer",
-    inputSimHits = "VTXDCollection",
+    inputSimHits = "VertexEndcapCollection",
     outputDigiHits = "VTXDDigis",
     outputSimDigiAssociation = "VTXDSimDigiLinks",
     detectorName = "Vertex",
-    readoutName = "VTXDCollection",
-    xResolution = outerVertexResolution_x, # mm, r direction
-    yResolution = outerVertexResolution_y, # mm, phi direction
-    tResolution = outerVertexResolution_t, # ns
+    readoutName = "VertexEndcapCollection",
+    xResolution = [outerVertexResolution_x, outerVertexResolution_x, outerVertexResolution_x], # mm, r direction
+    yResolution = [outerVertexResolution_y, outerVertexResolution_y, outerVertexResolution_y], # mm, phi direction
+    tResolution = [outerVertexResolution_t, outerVertexResolution_t, outerVertexResolution_t], # ns
     forceHitsOntoSurface = False,
     OutputLevel = INFO
 )
@@ -130,8 +117,7 @@ from Configurables import ApplicationMgr
 application_mgr = ApplicationMgr(
     TopAlg = [
 			  inp,
-              vtxib_digitizer,
-              vtxob_digitizer,
+              vtxb_digitizer,
               vtxd_digitizer,
               #dch_digitizer,
               tracksFromGenParticles, 


### PR DESCRIPTION
Update to allow to work with new IDEA_o1_v03 vertex, that has only one readout for all vertex barrel layers.
Related to https://github.com/key4hep/k4RecTracker/pull/33 

@BrieucF 