### PR TITLE
Don't use deprecated properties, fix algorithm name

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -111,8 +111,8 @@ ExtSvc += [geoservice]
 from k4FWCore import IOSvc
 from Configurables import EventDataSvc
 io_svc = IOSvc("IOSvc")
-io_svc.input = inputfile
-io_svc.output = outputfile
+io_svc.Input = inputfile
+io_svc.Output = outputfile
 ExtSvc += [EventDataSvc("EventDataSvc")]
 
 # GDML dump of detector model

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -124,7 +124,7 @@ if dumpGDML:
 # Tracking
 # Create tracks from gen particles
 from Configurables import TracksFromGenParticles
-tracksFromGenParticles = TracksFromGenParticles("TracksFromGenParticles",
+tracksFromGenParticles = TracksFromGenParticles("CreateTracksFromGenParticles",
                                                InputGenParticles = ["MCParticles"],
                                                OutputTracks = ["TracksFromGenParticles"],
                                                OutputMCRecoTrackParticleAssociation = ["TracksFromGenParticlesAssociation"],

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -6,8 +6,8 @@ from Gaudi.Configuration import *
 # Loading the input SIM file, defining output file
 #from k4FWCore import IOSvc
 #io_svc = IOSvc("IOSvc")
-#io_svc.input = "IDEA_sim.root"
-#io_svc.output = "IDEA_sim_digi_reco.root"
+#io_svc.Input = "IDEA_sim.root"
+#io_svc.Output = "IDEA_sim_digi_reco.root"
 
 # For now still use the old IO service
 from Configurables import k4DataSvc, PodioInput


### PR DESCRIPTION
Lowercase `input` and `output` properties of `IOSvc` are deprecated in favor of `Input` and `Output` key4hep/k4FWCore#213

---

The name `TracksFromGenParticles` was used for both an algorithm instance and data-object created by it. This seems to be non-issue for processing correctness but might still confuse some services.
For instance scheduling precedence rules obtained from `PrecedenceSvc` reports that `TracksFromGenParticles` object doesn't have an origin and `TracksFromGenParticles` algorithm produces `TracksFromGenParticlesAssociations` data-object (correct) and itself (wrong)
![image](https://github.com/user-attachments/assets/8d466c98-abb2-4cad-a2a6-ab5d7557c5a8)

Corrected graph after renaming algortihm:
![image](https://github.com/user-attachments/assets/52c61970-1a4b-4834-8f72-70c4405f0ff5)


