### PR TITLE
Remove superseded HCal positioning tool

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v02/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v02/run_digi_reco.py
@@ -195,8 +195,8 @@ if runHCal:
     # createHcalEndcapCells.hits.Path="HCalEndcapHits"
     # createHcalEndcapCells.cells.Path="HCalEndcapCells"
 
-    from Configurables import CellPositionsHCalBarrelPhiThetaSegTool
-    cellPositionHcalBarrelTool = CellPositionsHCalBarrelPhiThetaSegTool(
+    from Configurables import CellPositionsHCalPhiThetaSegTool
+    cellPositionHcalBarrelTool = CellPositionsHCalPhiThetaSegTool(
         "CellPositionsHCalBarrel",
         readoutName=hcalBarrelReadoutName,
         OutputLevel=INFO


### PR DESCRIPTION
CellPositionsHCalBarrelPhiThetaSegTool was replaced by CellPositionsHCalPhiThetaSegTool, which does the same thing for the barrel, but has updated positioning for the endcap, and removed in https://github.com/HEP-FCC/k4RecCalorimeter/pull/127
Replacing here the tool in order to be able the ALLEGRO_o1_v02 reconstruction