### PR TITLE
various updates to ALLEGRO digi-reco script

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/README.md
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/README.md
@@ -7,6 +7,16 @@ If you need to modify the geometry, follow instructions [here](https://fcc-ee-de
 source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
 ```
 
+Retrieve the files needed later for digitization/reconstruction (e.g. noise values, machine learning models for calibration, ...)
+NB: if you do not have direct access to eos, you can retrieve those files from here: `https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/`
+```
+cp /eos/project/f/fccsw-web/www/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/* .
+```
+or
+```
+scp <user>@lxplus.cern.ch:/eos/project/f/fccsw-web/www/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/* .
+```
+
 ## Running the simulation
 ```
 ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --numberOfEvents 100 --outputFile ALLEGRO_sim.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml 
@@ -14,10 +24,6 @@ ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particl
 
 ## Running the digitization and reconstruction
 ```
-# Retrieve the files needed for digitization/reconstruction (e.g. noise values, machine learning models for calibration, ...)
-# NB: if you do not have direct access to eos, you can retrieve those files from here: https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ 
-cp /eos/project/f/fccsw-web/www/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/* .
-# run the digitization and reconstruction
 k4run run_digi_reco.py
 # you can then print the rootfile content with
 podio-dump ALLEGRO_sim_digi_reco.root  


### PR DESCRIPTION
In the README, move part about copying calibration files before running ddsim, so that file ALLEGRO_sim.root is not overridden by the one in the calibration area, which is outdated (we should update it but I had no permission to delete the old one)

In run_digi_reco.py:
- enable new eventcounter
- make various options configurable from the command line to avoid having to manually edit the script when rerunning with different options
- add options for including xtalk
- fix output configuration