### PR TITLE
Replace DCH digitizer in synchronize to k4RecTracker

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/ctest_sim_digi_reco.sh
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/ctest_sim_digi_reco.sh
@@ -13,5 +13,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # run the SIM step
 ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --numberOfEvents 10 --outputFile IDEA_sim.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml --steeringFile $SCRIPT_DIR/SteeringFile_IDEA_o1_v03.py
 
+# download file for cluster counting technique
+DCHfilename="https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/DataAlgFORGEANT.root"
+wget --no-clobber $DCHfilename
+
 # run the DIGI/RECO step
 k4run $SCRIPT_DIR/run_digi_reco.py

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -104,7 +104,7 @@ dch_digitizer = DCHdigi_v01("DCHdigi",
     fileDataAlg = "DataAlgFORGEANT.root",
     calculate_dndx = False, # cluster counting disabled (to be validated, see FCC-config#239)
     create_debug_histograms = True,
-    zResolution_mm = 1, # in mm
+    zResolution_mm = 30., # in mm - Note: At this point, the z resolution comes without the stereo measurement
     xyResolution_mm = 0.1 # in mm
 )
 

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -102,10 +102,10 @@ dch_digitizer = DCHdigi_v01("DCHdigi",
     DCH_simhits = ["DCHCollection"],
     DCH_name = "DCH_v2",
     fileDataAlg = "DataAlgFORGEANT.root",
-    calculate_dndx = True,
+    calculate_dndx = False, # cluster counting disabled (to be validated, see FCC-config#239)
     create_debug_histograms = True,
-    zResolution_mm = 1,
-    xyResolution_mm = 0.1
+    zResolution_mm = 1, # in mm
+    xyResolution_mm = 0.1 # in mm
 )
 
 # Create tracks from gen particles

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -98,14 +98,15 @@ siwrd_digitizer = VTXdigitizer("SiWrDdigitizer",
 )
 
 from Configurables import DCHdigi_v01
-DCHdigi = DCHdigi_v01("DCHdigi")
-DCHdigi.DCH_simhits = ["DCHCollection"]
-DCHdigi.DCH_name = "DCH_v2"
-DCHdigi.fileDataAlg = "DataAlgFORGEANT.root"
-DCHdigi.calculate_dndx = True
-DCHdigi.create_debug_histograms = True
-DCHdigi.zResolution_mm = 1
-DCHdigi.xyResolution_mm = 0.1
+dch_digitizer = DCHdigi_v01("DCHdigi",
+    DCH_simhits = ["DCHCollection"],
+    DCH_name = "DCH_v2",
+    fileDataAlg = "DataAlgFORGEANT.root",
+    calculate_dndx = True,
+    create_debug_histograms = True,
+    zResolution_mm = 1,
+    xyResolution_mm = 0.1
+)
 
 # Create tracks from gen particles
 from Configurables import TracksFromGenParticles
@@ -149,7 +150,7 @@ application_mgr = ApplicationMgr(
               vtxd_digitizer,
               siwrb_digitizer,
               siwrd_digitizer,
-              DCHdigi,
+              dch_digitizer,
               tracksFromGenParticles, 
               plotTrackDCHHitDistances,
               out

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -97,18 +97,15 @@ siwrd_digitizer = VTXdigitizer("SiWrDdigitizer",
     OutputLevel = INFO
 )
 
-# digitize drift chamber hits, waiting to merge the digitizer for the new drift chamber
-#from Configurables import DCHsimpleDigitizerExtendedEdm
-#dch_digitizer = DCHsimpleDigitizerExtendedEdm("DCHsimpleDigitizerExtendedEdm",
-#    inputSimHits = "CDCHHits",
-#    outputDigiHits = "CDCHDigis",
-#    outputSimDigiAssociation = "DC_simDigiAssociation",
-#    readoutName = "CDCHHits",
-#    xyResolution = 0.1, # mm
-#    zResolution = 1, # mm
-#    debugMode = True,
-#    OutputLevel = INFO
-#)
+from Configurables import DCHdigi_v01
+DCHdigi = DCHdigi_v01("DCHdigi")
+DCHdigi.DCH_simhits = ["DCHCollection"]
+DCHdigi.DCH_name = "DCH_v2"
+DCHdigi.fileDataAlg = "DataAlgFORGEANT.root"
+DCHdigi.calculate_dndx = True
+DCHdigi.create_debug_histograms = True
+DCHdigi.zResolution_mm = 1
+DCHdigi.xyResolution_mm = 0.1
 
 # Create tracks from gen particles
 from Configurables import TracksFromGenParticles
@@ -139,7 +136,7 @@ out.outputCommands = ["keep *"]
 out.filename = "IDEA_sim_digi_reco.root"
 
 # Profiling
-from Configurables import AuditorSvc, ChronoAuditor
+from Configurables import AuditorSvc, ChronoAuditor, UniqueIDGenSvc
 chra = ChronoAuditor()
 audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
@@ -152,7 +149,7 @@ application_mgr = ApplicationMgr(
               vtxd_digitizer,
               siwrb_digitizer,
               siwrd_digitizer,
-              #dch_digitizer,
+              DCHdigi,
               tracksFromGenParticles, 
               plotTrackDCHHitDistances,
               out
@@ -160,7 +157,7 @@ application_mgr = ApplicationMgr(
     EvtSel = 'NONE',
     EvtMax   = -1,
     #ExtSvc = [root_hist_svc, EventDataSvc("EventDataSvc"), geoservice, audsvc],
-    ExtSvc = ['RndmGenSvc', root_hist_svc, geoservice, evtsvc, audsvc],
+    ExtSvc = ['RndmGenSvc', root_hist_svc, geoservice, evtsvc, audsvc, UniqueIDGenSvc("uidSvc")],
     StopOnSignal = True,
  )
 


### PR DESCRIPTION
Replacing IDEA drift chamber digitizer in synchronize to what persists in the [k4RecTracker](https://github.com/key4hep/k4RecTracker/blob/master/DCHdigi/test/test_DCHdigi/runDCHdigi.py).

Works when tested in the `lxplus` with key4hep nightlies. The warning `ROOT::Math::GSL...WARNING input domain error` appears, but it seems this behavior was also seen previously (slide7 in the [link](https://indico.cern.ch/event/1441999/contributions/6079905/attachments/2908054/5102601/driftchamberv2_digi_atd_240806.pdf))? @atolosadelgado 