### PR TITLE
tt -> WbWb with CKM mix and correct tau

### DIFF
--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tallTheavy_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tallTheavy_ecm365.sin
@@ -1,0 +1,108 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV,
+#    t -> W b -> anything, tbar -> W b -> c/b quarks
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+#    REMARK: The generation for this card may take long
+#            because there are many processes
+#            and the phasespace integration can take ~12 hours.
+#            But after this overhead, the event generation is as fast as other cards.
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Configure
+
+?resonance_history = true
+resonance_on_shell_limit = 10
+resonance_background_factor = 0 
+
+# Process
+
+alias lep  = e1:e2
+alias neut = n1:n2
+alias Lep  = E1:E2
+alias Neut = N1:N2
+me = 0
+mmu = 0
+
+process proc = e1, E1 =>  (U, b, B, Lep, neut, b) + (U, b, B, E3, n3, b)
+                        + (C, d, B, Lep, neut, b) + (C, d, B, E3, n3, b)
+                        + (C, s, B, Lep, neut, b) + (C, s, B, E3, n3, b)
+                        + (C, b, B, Lep, neut, b) + (C, b, B, E3, n3, b)
+                        + (U, b, B, u, D, b) + (U, b, B, u, S, b) + (U, b, B, u, B, b)
+                        + (U, b, B, c, D, b) + (U, b, B, c, S, b) + (U, b, B, c, B, b)
+                        + (C, d, B, u, D, b) + (C, d, B, u, S, b) + (C, d, B, u, B, b)
+                        + (C, d, B, c, D, b) + (C, d, B, c, S, b) + (C, d, B, c, B, b)
+                        + (C, s, B, u, D, b) + (C, s, B, u, S, b) + (C, s, B, u, B, b)
+                        + (C, s, B, c, D, b) + (C, s, B, c, S, b) + (C, s, B, c, B, b)
+                        + (C, b, B, u, D, b) + (C, b, B, u, S, b) + (C, b, B, u, B, b)
+                        + (C, b, B, c, D, b) + (C, b, B, c, S, b) + (C, b, B, c, B, b) 
+                        {$restrictions = "3+4~W- && 6+7~W+ && 3+4+5~tbar && 6+7+8~t"}
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tallTlep_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tallTlep_ecm365.sin
@@ -1,0 +1,102 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV,
+#    t -> W b -> anything, tbar -> W b -> lep
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+#    REMARK: The generation for this card may take long
+#            because there are many processes 
+#            and the phasespace integration can take ~12 hours.
+#            But after this overhead, the event generation is as fast as other cards.
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Configure
+
+?resonance_history = true
+resonance_on_shell_limit = 10
+resonance_background_factor = 0 
+
+# Process
+
+alias lep  = e1:e2
+alias neut = n1:n2
+alias Lep  = E1:E2
+alias Neut = N1:N2
+me = 0
+mmu = 0
+
+process proc = e1, E1 =>  (lep, Neut, B, Lep, neut, b) + (lep, Neut, B, E3, n3, b)
+                        + (e3,  N3,   B, Lep, neut, b) + (e3,  N3,   B, E3, n3, b)
+                        + (lep, Neut, B, u, D, b) + (lep, Neut, B, u, S, b) + (lep, Neut, B, u, B, b)
+                        + (lep, Neut, B, c, D, b) + (lep, Neut, B, c, S, b) + (lep, Neut, B, c, B, b)
+                        + (e3,  N3,   B, u, D, b) + (e3,  N3,   B, u, S, b) + (e3,  N3,   B, u, B, b)
+                        + (e3,  N3,   B, c, D, b) + (e3,  N3,   B, c, S, b) + (e3,  N3,   B, c, B, b)
+                        {$restrictions = "3+4~W- && 6+7~W+ && 3+4+5~tbar && 6+7+8~t"}
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tallTlight_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tallTlight_ecm365.sin
@@ -1,0 +1,102 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV,
+#    t -> W b -> anything, tbar -> W b -> light quarks
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+#    REMARK: The generation for this card may take long
+#            because there are many processes
+#            and the phasespace integration can take ~12 hours.
+#            But after this overhead, the event generation is as fast as other cards.
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Configure
+
+?resonance_history = true
+resonance_on_shell_limit = 10
+resonance_background_factor = 0 
+
+# Process
+
+alias lep  = e1:e2
+alias neut = n1:n2
+alias Lep  = E1:E2
+alias Neut = N1:N2
+me = 0
+mmu = 0
+
+process proc = e1, E1 =>  (U, d, B, Lep, neut, b) + (U, d, B, E3, n3, b)
+                        + (U, s, B, Lep, neut, b) + (U, s, B, E3, n3, b)
+                        + (U, d, B, u, D, b) + (U, d, B, u, S, b) + (U, d, B, u, B, b)
+                        + (U, d, B, c, D, b) + (U, d, B, c, S, b) + (U, d, B, c, B, b)
+                        + (U, s, B, u, D, b) + (U, s, B, u, S, b) + (U, s, B, u, B, b)
+                        + (U, s, B, c, D, b) + (U, s, B, c, S, b) + (U, s, B, c, B, b) 
+                        {$restrictions = "3+4~W- && 6+7~W+ && 3+4+5~tbar && 6+7+8~t"}
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_theavyTall_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_theavyTall_ecm365.sin
@@ -1,0 +1,108 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV,
+#    t -> W b -> c/b quarks, tbar -> W b -> anything
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+#    REMARK: The generation for this card may take long
+#            because there are many processes
+#            and the phasespace integration can take ~12 hours.
+#            But after this overhead, the event generation is as fast as other cards.
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Configure
+
+?resonance_history = true
+resonance_on_shell_limit = 10
+resonance_background_factor = 0 
+
+# Process
+
+alias lep  = e1:e2
+alias neut = n1:n2
+alias Lep  = E1:E2
+alias Neut = N1:N2
+me = 0
+mmu = 0
+
+process proc = e1, E1 =>  (u, B, b, lep, Neut, B) + (u, B, b, e3, N3, B)
+                        + (c, D, b, lep, Neut, B) + (c, D, b, e3, N3, B)
+                        + (c, S, b, lep, Neut, B) + (c, S, b, e3, N3, B)
+                        + (c, B, b, lep, Neut, B) + (c, B, b, e3, N3, B)
+                        + (u, B, b, U, d, B) + (u, B, b, U, s, B) + (u, B, b, U, b, B)
+                        + (u, B, b, C, d, B) + (u, B, b, C, s, B) + (u, B, b, C, b, B)
+                        + (c, D, b, U, d, B) + (c, D, b, U, s, B) + (c, D, b, U, b, B)
+                        + (c, D, b, C, d, B) + (c, D, b, C, s, B) + (c, D, b, C, b, B)
+                        + (c, S, b, U, d, B) + (c, S, b, U, s, B) + (c, S, b, U, b, B)
+                        + (c, S, b, C, d, B) + (c, S, b, C, s, B) + (c, S, b, C, b, B)
+                        + (c, B, b, U, d, B) + (c, B, b, U, s, B) + (c, B, b, U, b, B)
+                        + (c, B, b, C, d, B) + (c, B, b, C, s, B) + (c, B, b, C, b, B) 
+                        {$restrictions = "3+4~W+ && 6+7~W- && 3+4+5~t && 6+7+8~tbar"}
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tlepTall_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tlepTall_ecm365.sin
@@ -1,0 +1,102 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV,
+#    t -> W b -> lep, tbar -> W b -> anything
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+#    REMARK: The generation for this card may take long
+#            because there are many processes 
+#            and the phasespace integration can take ~12 hours.
+#            But after this overhead, the event generation is as fast as other cards.
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Configure
+
+?resonance_history = true
+resonance_on_shell_limit = 10
+resonance_background_factor = 0 
+
+# Process
+
+alias lep  = e1:e2
+alias neut = n1:n2
+alias Lep  = E1:E2
+alias Neut = N1:N2
+me = 0
+mmu = 0
+
+process proc = e1, E1 =>  (Lep, neut, b, lep, Neut, B) + (Lep, neut, b, e3, N3, B)
+                        + (E3,  n3,   b, lep, Neut, B) + (E3,  n3,   b, e3, N3, B)
+                        + (Lep, neut, b, U, d, B) + (Lep, neut, b, U, s, B) + (Lep, neut, b, U, b, B)
+                        + (Lep, neut, b, C, d, B) + (Lep, neut, b, C, s, B) + (Lep, neut, b, C, b, B)
+                        + (E3,  n3,   b, U, d, B) + (E3,  n3,   b, U, s, B) + (E3,  n3,   b, U, b, B)
+                        + (E3,  n3,   b, C, d, B) + (E3,  n3,   b, C, s, B) + (E3,  n3,   b, C, b, B)
+                        {$restrictions = "3+4~W+ && 6+7~W- && 3+4+5~t && 6+7+8~tbar"}
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+

--- a/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tlightTall_ecm365.sin
+++ b/FCCee/Generator/Whizard/v3.0.3/wzp6_ee_SM_tt_tWbTWb_tlightTall_ecm365.sin
@@ -1,0 +1,102 @@
+########################################################################
+#
+# Copyright (C) 1999-2019 by 
+#     Wolfgang Kilian <kilian@physik.uni-siegen.de>
+#     Thorsten Ohl <ohl@physik.uni-wuerzburg.de>
+#     Juergen Reuter <juergen.reuter@desy.de>
+#     with contributions from
+#     cf. main AUTHORS file
+#
+# WHIZARD is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by 
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# WHIZARD is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+########################################################################
+#
+#    e+ e- -> Z*/gamma* -> t tbar at 365 GeV,
+#    t -> W b -> light quarks, tbar -> W b -> anything
+#
+#    Whizard version is 3.1.0, as in key4hep-stack/2023-04-08
+#
+#    REMARK: The generation for this card may take long
+#            because there are many processes
+#            and the phasespace integration can take ~12 hours.
+#            But after this overhead, the event generation is as fast as other cards.
+#
+########################################################################
+
+model = SM_CKM
+
+# Center of mass energy
+sqrts = 365 GeV
+
+# Configure
+
+?resonance_history = true
+resonance_on_shell_limit = 10
+resonance_background_factor = 0 
+
+# Process
+
+alias lep  = e1:e2
+alias neut = n1:n2
+alias Lep  = E1:E2
+alias Neut = N1:N2
+me = 0
+mmu = 0
+
+process proc = e1, E1 =>  (u, D, b, lep, Neut, B) + (u, D, b, e3, N3, B)
+                        + (u, S, b, lep, Neut, B) + (u, S, b, e3, N3, B)
+                        + (u, D, b, U, d, B) + (u, D, b, U, s, B) + (u, D, b, U, b, B)
+                        + (u, D, b, C, d, B) + (u, D, b, C, s, B) + (u, D, b, C, b, B)
+                        + (u, S, b, U, d, B) + (u, S, b, U, s, B) + (u, S, b, U, b, B)
+                        + (u, S, b, C, d, B) + (u, S, b, C, s, B) + (u, S, b, C, b, B) 
+                        {$restrictions = "3+4~W+ && 6+7~W- && 3+4+5~t && 6+7+8~tbar"}
+
+beams = e1, E1 => gaussian => isr
+?keep_beams  = true    
+?keep_remnants = true
+
+! beams = e1, E1 => gaussian 
+gaussian_spread1 = 0.221%
+gaussian_spread2 = 0.221%
+
+
+?isr_handler       = true
+$isr_handler_mode = "recoil"
+isr_alpha          = 0.0072993
+isr_mass           = 0.000511
+
+
+! Parton shower and hadronization
+?ps_fsr_active          = true
+?ps_isr_active          = false
+?hadronization_active   = true
+$shower_method          = "PYTHIA6"
+!?ps_PYTHIA_verbose     = true
+
+
+$ps_PYTHIA_PYGIVE = "MSTJ(28)=0; PMAS(25,1)=125.; PMAS(25,2)=0.4143E-02; MSTJ(41)=2; MSTU(22)=2000; PARJ(21)=0.40000; PARJ(41)=0.11000; PARJ(42)=0.52000; PARJ(81)=0.25000; PARJ(82)=1.90000; MSTJ(11)=3; PARJ(54)=-0.03100; PARJ(55)=-0.00200; PARJ(1)=0.08500; PARJ(3)=0.45000; PARJ(4)=0.02500; PARJ(2)=0.31000; PARJ(11)=0.60000; PARJ(12)=0.40000; PARJ(13)=0.72000; PARJ(14)=0.43000; PARJ(15)=0.08000; PARJ(16)=0.08000; PARJ(17)=0.17000; MSTP(3)=1;MSTP(71)=1; MSTP(151)=1; PARP(151)=0.0273; PARP(152)=4.88e-5; PARP(153)=1.33; PARP(154)=1.337; MSTJ(22)=4; PARJ(73)=2250; PARJ(74)=2500"
+
+integrate (proc) { iterations = 10:100000:"gw", 10:200000:"" }
+
+# n_events should be passed by the EventProducer
+# n_events = 100000
+
+
+sample_format =  stdhep
+$extension_stdhep = "stdhep"
+
+
+simulate (proc) {checkpoint = 100}
+


### PR DESCRIPTION
A few tt -> WbWb cards as the bkg processes for t -> W s search. 
Full CKM is enabled. 
Also final states are properly generated, addressing issue in previous cards ("wzp6_ee_SM_tt_thadTlep_noCKMmix_keepPolInfo_ecm365" etc.), where taus are set to 0 mass and do not decay properly.