### PR TITLE
Adding muon_digitizer implemnted with DDPlanarDigi

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -111,17 +111,17 @@ dch_digitizer = DCHdigi_v01("DCHdigi",
 from Configurables import DDPlanarDigi
 
 muon_digitizer = DDPlanarDigi()
-    muon_digitizer.SubDetectorName = "Muon-System"
-    muon_digitizer.EncodingStringParameterName = "MuonSystemReadoutID"
-    muon_digitizer.CellIDBits = "23"
-    muon_digitizer.IsStrip = False
-    muon_digitizer.ResolutionU = [0.4] # in mm, one value for all layers, or different values on the # of layers
-    muon_digitizer.ResolutionV = [0.4] # in mm, one value for all layers, or different values on the # of layers
-    muon_digitizer.ForceHitsOntoSurface = True
-    muon_digitizer.SimTrackerHitCollectionName = ["MuonSystemCollection"]
-    muon_digitizer.SimTrkHitRelCollection = ["MSTrackerHitRelations"]
-    muon_digitizer.TrackerHitCollectionName = ["MSTrackerHits"]
-    #muon_digitizer.OutputLevel = 1  # DEBUG level
+muon_digitizer.SubDetectorName = "Muon-System"
+muon_digitizer.EncodingStringParameterName = "MuonSystemReadoutID"
+muon_digitizer.CellIDBits = "23"
+muon_digitizer.IsStrip = False
+muon_digitizer.ResolutionU = [0.4] # in mm, one value for all layers, or different values on the # of layers
+muon_digitizer.ResolutionV = [0.4] # in mm, one value for all layers, or different values on the # of layers
+muon_digitizer.ForceHitsOntoSurface = True
+muon_digitizer.SimTrackHitCollectionName = ["MuonSystemCollection"]
+muon_digitizer.SimTrkHitRelCollection = ["MSTrackerHitRelations"]
+muon_digitizer.TrackerHitCollectionName = ["MSTrackerHits"]
+#muon_digitizer.OutputLevel = 1  # DEBUG level
 
 # Create tracks from gen particles
 from Configurables import TracksFromGenParticles


### PR DESCRIPTION
- Adding muon digitizer depending on DDPlanarDigi from K4Reco.
- It smears the hit in 2 dimensions.
- The `CellIDBits` is limited to 23 bits, up to the surfaces of the chambers, no further surfaces for smaller segmentations (strips).
- This works with changes done in k4geo here : [K4geo/PR444](https://github.com/key4hep/k4geo/pull/444).