### PR TITLE
Removing the energy deposition filter for DCH & Muon-System

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/SteeringFile_IDEA_o1_v03.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/SteeringFile_IDEA_o1_v03.py
@@ -188,7 +188,8 @@ SIM.filter.filters = {
 }
 
 ##  a map between patterns and filter objects, using patterns to attach filters to sensitive detector
-SIM.filter.mapDetFilter = {}
+SIM.filter.mapDetFilter["DCH_v2"] = "edep0"
+SIM.filter.mapDetFilter["Muon-System"] = "edep0"
 
 ##  default filter for tracking sensitive detectors; this is applied if no other filter is used for a tracker
 SIM.filter.tracker = "edep1kev"


### PR DESCRIPTION
Setting the edep threshold to 0, in both drift chamber and muon system.
This change is crucial, since the previous threshold (1kev) made big loss in simHits.