### PR TITLE
Add LANGUAGES CXX to the project() call in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
 
-project(FCC-config)
+project(FCC-config LANGUAGES CXX)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Technically could be `NONE` but since `CMAKE_INSTALL_DATADIR` is being used, a language has to be specified.