### PR TITLE
dN/dx parametrisation from tracks via deplhes added to default run_digi_reco scripts

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -234,6 +234,19 @@ if addTracks:
                                                     OutputLevel=INFO)
     TopAlg += [tracksFromGenParticles]
 
+    # Calculate dNdx from tracks
+    from Configurables import TrackdNdxDelphesBased
+    dNdxFromTracks = TrackdNdxDelphesBased("dNdxFromTracks",
+                                    InputLinkCollection=tracksFromGenParticles.OutputMCRecoTrackParticleAssociation,
+                                    OutputCollection=["DCHdNdxCollection"],
+                                    ZmaxParameterName="DCH_gas_Lhalf",
+                                    ZminParameterName="DCH_gas_Lhalf",
+                                    RminParameterName="DCH_gas_inner_cyl_R",
+                                    RmaxParameterName="DCH_gas_outer_cyl_R",
+                                    FillFactor=1.0,
+                                    OutputLevel=INFO)
+    TopAlg += [dNdxFromTracks]
+
 
 # Tracker digitisation
 if digitiseTrackerHits:

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -6,7 +6,7 @@
 #
 
 # Logger
-from Gaudi.Configuration import INFO, DEBUG, VERBOSE
+from Gaudi.Configuration import INFO, DEBUG, VERBOSE, ERROR
 # units and physical constants
 from GaudiKernel.PhysicalConstants import pi
 
@@ -244,7 +244,7 @@ if addTracks:
                                     RminParameterName="DCH_gas_inner_cyl_R",
                                     RmaxParameterName="DCH_gas_outer_cyl_R",
                                     FillFactor=1.0,
-                                    OutputLevel=INFO)
+                                    OutputLevel=ERROR)
     TopAlg += [dNdxFromTracks]
 
 

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -147,7 +147,7 @@ dNdxFromTracks = TrackdNdxDelphesBased("dNdxFromTracks",
                                   RminParameterName="DCH_gas_inner_cyl_R",
                                   RmaxParameterName="DCH_gas_outer_cyl_R",
                                   FillFactor=1.0,
-                                  OutputLevel=INFO)
+                                  OutputLevel=ERROR)
 
 ################ Output
 io_svc.outputCommands = ["keep *"]

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -137,6 +137,18 @@ hps = RootHistSvc("HistogramPersistencySvc")
 root_hist_svc = RootHistoSink("RootHistoSink")
 root_hist_svc.FileName = "TrackHitDistances.root"
 
+# Calculate dNdx from tracks
+from Configurables import TrackdNdxDelphesBased
+dNdxFromTracks = TrackdNdxDelphesBased("dNdxFromTracks",
+                                  InputLinkCollection=tracksFromGenParticles.OutputMCRecoTrackParticleAssociation,
+                                  OutputCollection=["DCHdNdxCollection"],
+                                  ZmaxParameterName="DCH_gas_Lhalf",
+                                  ZminParameterName="DCH_gas_Lhalf",
+                                  RminParameterName="DCH_gas_inner_cyl_R",
+                                  RmaxParameterName="DCH_gas_outer_cyl_R",
+                                  FillFactor=1.0,
+                                  OutputLevel=INFO)
+
 ################ Output
 io_svc.outputCommands = ["keep *"]
 
@@ -157,6 +169,7 @@ application_mgr = ApplicationMgr(
               muon_digitizer,
               tracksFromGenParticles, 
               plotTrackDCHHitDistances,
+              dNdxFromTracks,
               ],
     EvtSel = 'NONE',
     EvtMax   = -1,


### PR DESCRIPTION
BEGINRELEASENOTES
- Added TrackdNdxFromDelphes to IDEA_o1_v03's and ALLEGRO_o1_v03's `run_digi_reco.py` Gaudi script

ENDRELEASENOTES

I tested that the `run_digi_reco.py` scripts still run with the instructions from the corresponding README