### PR TITLE
fix inclusive tau decays

### DIFF
--- a/FCCee/Generator/EvtGen/Bs2TauTau.dec
+++ b/FCCee/Generator/EvtGen/Bs2TauTau.dec
@@ -15,7 +15,7 @@ Enddecay
 CDecay Bsbar_SIGNAL
 #
 Decay Mytau-
-  1.00        TAUOLA 5;
+  1.00        TAUOLA 0;
 Enddecay
 CDecay Mytau+
 #


### PR DESCRIPTION
Card is intended for inclusive tau decays
Previously with `TAUOLA 5` it was tau to a1 (to 3 pi)
Fixed with `TAUOLA 0`, which is all decays