### PR TITLE
Fix allegro configuration with noise.

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -982,10 +982,11 @@ def setupTopoClusters(inputCells,
         if addPi0RecoTool:
             from Configurables import PairCaloClustersPi0
             Pi0RecoAlg = PairCaloClustersPi0(
-                "resolvedPi0FromClusterPair",
+                "resolvedPi0FromClusterPair" + outputClusters,
                 inClusters=augmentClusterAlg.outClusters.Path,
                 unpairedClusters="Unpaired" + augmentClusterAlg.outClusters.Path,
-                reconstructedPi0="ResolvedPi0Particle",
+                pairedClusters='pairedClusters' + augmentClusterAlg.outClusters.Path,
+                reconstructedPi0="ResolvedPi0Particle" + outputClusters,
                 massPeak=0.122201, # values determined from a dedicated study
                 massLow=0.0754493,
                 massHigh=0.153543,


### PR DESCRIPTION
The allegro run_digi_reco.py configuration doesn't with if --addNoise is used because we schedule the resolvedPi0FromClusterPair twice with identical name and outputs.  Fix by qualifying with the cluster name.

To reproduce:

```
$ mkdir allegro-noisetest
$ cd allegro-noisetest
$ . /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh -r 2025-10-07
$ git clone https://github.com/HEP-FCC/FCC-config
$ FCC-config/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/ctest_sim_digi_reco.sh 
$ k4run FCC-config/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py --addNoise --includeHCal --includeMuon --trkdigi --addTracks --calibrateClusters --saveCells 2>&1|tee log
```

This gives errors:

```
4FWCore__Algs    WARNING resolvedPi0FromClusterPair already exists - append failed!!!
k4FWCore__Algs      ERROR Unable to configure one or more sequencer members