### PR TITLE
More realistic SiPM parameters for DRC

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -209,10 +209,11 @@ sipmEdep = SimulateSiPMwithEdep("SimulateSiPMwithEdep",
         0.
     ],
     # empirical value to keep (scint npe / ceren npe) =~ 5
-    scintYield = 0.565,
-    scaleADC = 0.0003897,
-    threshold = 1.5,
-    params = {"ccgv" : 0.25},
+    scintYield = 0.565, # effective scintillation yield (k*13.6/keV)
+                        # k responsible for numerical aperture
+    scaleADC = 0.0003897, # equalization constant from ADC to GeV
+    threshold = 1.5, # ADC integration threshold
+    params = {"ccgv" : 0.25}, # cell-to-cell gain variation (and others if needed)
     gateLength = 80., # ns
     SNR = 14., # gain(10um)/gain(15um) = 0.5
 )
@@ -245,15 +246,16 @@ sipmOptical = SimulateSiPMwithOpticalPhoton("SimulateSiPMwithOpticalPhoton",
         0.33, 0.32, 0.30, 0.27, 0.22,
         0.12, 0.
     ],
-    scaleADC = 0.0005762,
+    scaleADC = 0.0005762, # equalization constant from ADC to GeV
     threshold = 1.5,
-    cellpitch = 15.,
+    cellpitch = 15., # um
     falltimeFast = 1.7, # ns
     gateLength = 80., # ns
     params = {
-        "ccgv" : 0.15,
+        "ccgv" : 0.15, # cell-to-cell gain variation
+                       # responsible for a single photon peak std. dev.
         "falltimeslow" : 15., # ns
-        "slowcomponentfraction" : 0.5
+        "slowcomponentfraction" : 0.5 # signal = (1-f)*fast + f*slow
     },
 )
 


### PR DESCRIPTION
The previous input parameters for SiPM emulation were based on the datasheet provided by Hamamatsu:
https://www.hamamatsu.com/jp/en/product/optical-sensors/mppc/mppc_mppc-array/s14160_series.html

However, it was found that the 'hidden' parameter not listed on the datasheet, cell-to-cell gain variation ("ccgv"), was way too optimistic compared to the actual lab-based V_bd measurement:
https://indico.cern.ch/event/1372221/#sc-3-1-update-on-sipm-characte

Also, the SiPM for the Cherenkov channel has been replaced from a 10um-pitch to a 15um-pitch to benefit from higher photo-detection efficiency.

As the sim calo hit contributions and waveforms are only needed for the digitization step, I added `drop` commands in the `IOSvc` to drop those collections by default. This saves about ~ 70% of the file size. Users can comment out them if they want those collections.

This PR needs HEP-FCC/k4RecCalorimeter#190 in the upstream

Here are some examples:

## 10 GeV muon (as a proxy of a MIP signal)
Note: displayed signals are above pedestal level (but include thermal dark count)

### Previous parameters (fixed ccgv = 5%):

#### Cherenkov ADC
<img width="450" height="300" alt="Mu10GeV_adcBefore_C" src="https://github.com/user-attachments/assets/79e6c602-42a1-4aef-b977-80679d440e7c" />

#### Scintillation ADC
<img width="450" height="300" alt="Mu10GeV_adcBefore_S" src="https://github.com/user-attachments/assets/fdc88bdb-66bf-4ef3-9341-ef21f8ccb1d2" />

### New parameters (ccgv for 10um pitch = 25%, ccgv for 15um pitch = 15%)

#### Cherenkov ADC
<img width="450" height="300" alt="Mu10GeV_adcAfter_C" src="https://github.com/user-attachments/assets/f2cf9a6b-5e35-4681-9d2d-a1f3f2bbc537" />

#### Scintillation ADC
<img width="450" height="300" alt="Mu10GeV_adcAfter_S" src="https://github.com/user-attachments/assets/72fedca1-3430-474e-9553-06a07cca76fa" />

#### Example Cherenkov waveform (gate length = 80 ns)
<img width="450" height="300" alt="Mu10GeV_waveform_C" src="https://github.com/user-attachments/assets/381ba349-eac5-4ee1-9587-11644c35caae" />

#### Example scintillation waveform (gate length = 80 ns)
<img width="450" height="300" alt="Mu10GeV_waveform_S" src="https://github.com/user-attachments/assets/6375990a-c31f-4d15-a2ea-51fe76ade826" />

## 20 GeV electron (signal with more photons)
Note: integration threshold at 1.5 photoelectron level (excludes thermal dark count)

#### Cherenkov ADC
<img width="450" height="300" alt="Ele20GeV_adcThres1p5_C" src="https://github.com/user-attachments/assets/d22f879a-e0a4-4cee-838d-382c62222a62" />

#### Scintillation ADC
<img width="450" height="300" alt="Ele20GeV_adcThres1p5_S" src="https://github.com/user-attachments/assets/49777413-26a0-4c6d-9f02-a7397af503b4" />


