### PR TITLE
Add GGTF algorithm configuration for IDEA and ALLEGRO

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/ctest_sim_digi_reco.sh
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/ctest_sim_digi_reco.sh
@@ -24,9 +24,10 @@ if ! test -f ./DataAlgForGEANT.root; then  # assumes that if the last file exist
   wget https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalE_turbine.root
   wget https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged_hcalB_hcalEndcap_phitheta.root
   wget https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged_ecalE_turbine_hcalB_hcalEndcap_phitheta.root
+  wget https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/IDEA_o1_v03/SimpleGatrIDEAv3o1.onnx
   wget https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/DataAlgFORGEANT.root
 fi
 
 # run the RECO step
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
-k4run $SCRIPT_DIR/run_digi_reco.py --includeHCal --includeMuon --runTrkHitDigitization --addTracks --calibrateClusters --saveCells
+k4run $SCRIPT_DIR/run_digi_reco.py --includeHCal --includeMuon --runTrkHitDigitization --addTracks --calibrateClusters --saveCells --runTrkFinder

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -338,7 +338,7 @@ if runTrkHitDigitization:
                                       outputDigiHits=vxd_barrel_digi_args["TrackerHitCollectionName"][0],
                                       outputSimDigiAssociation= vxd_barrel_digi_args["SimTrkHitRelCollection"][0],
                                       detectorName=vxd_barrel_digi_args["SubDetectorName"],
-                                      readoutName=vxd_barrel_digi_args["SimTrkHitRelCollection"][0],
+                                      readoutName=vxd_barrel_digi_args["SimTrackHitCollectionName"][0],
                                       xResolution=vxd_barrel_digi_args["ResolutionU"],  # mm, r-phi direction
                                       yResolution=vxd_barrel_digi_args["ResolutionV"],  # mm, z direction
                                       tResolution=vxd_barrel_digi_args["ResolutionT"],  # ns
@@ -352,7 +352,7 @@ if runTrkHitDigitization:
                                       outputDigiHits=vxd_endcap_digi_args["TrackerHitCollectionName"][0],
                                       outputSimDigiAssociation= vxd_endcap_digi_args["SimTrkHitRelCollection"][0],
                                       detectorName=vxd_endcap_digi_args["SubDetectorName"],
-                                      readoutName=vxd_endcap_digi_args["SimTrkHitRelCollection"][0],
+                                      readoutName=vxd_endcap_digi_args["SimTrackHitCollectionName"][0],
                                       xResolution=vxd_endcap_digi_args["ResolutionU"],  # mm, r direction
                                       yResolution=vxd_endcap_digi_args["ResolutionV"],  # mm, phi direction
                                       tResolution=vxd_endcap_digi_args["ResolutionT"],  # ns
@@ -366,7 +366,7 @@ if runTrkHitDigitization:
                                       outputDigiHits=siWr_barrel_digi_args["TrackerHitCollectionName"][0],
                                       outputSimDigiAssociation= siWr_barrel_digi_args["SimTrkHitRelCollection"][0],
                                       detectorName=siWr_barrel_digi_args["SubDetectorName"],
-                                      readoutName=siWr_barrel_digi_args["SimTrkHitRelCollection"][0],
+                                      readoutName=siWr_barrel_digi_args["SimTrackHitCollectionName"][0],
                                       xResolution=siWr_barrel_digi_args["ResolutionU"],  # mm, r-phi direction
                                       yResolution=siWr_barrel_digi_args["ResolutionV"],  # mm, z direction
                                       tResolution=siWr_barrel_digi_args["ResolutionT"],  # ns
@@ -380,7 +380,7 @@ if runTrkHitDigitization:
                                        outputDigiHits=siWr_endcap_digi_args["TrackerHitCollectionName"][0],
                                        outputSimDigiAssociation= siWr_endcap_digi_args["SimTrkHitRelCollection"][0],
                                        detectorName=siWr_endcap_digi_args["SubDetectorName"],
-                                       readoutName=siWr_endcap_digi_args["SimTrkHitRelCollection"][0],
+                                       readoutName=siWr_endcap_digi_args["SimTrackHitCollectionName"][0],
                                        xResolution=siWr_endcap_digi_args["ResolutionU"],  # mm, r direction
                                        yResolution=siWr_endcap_digi_args["ResolutionV"],  # mm, phi direction
                                        tResolution=siWr_endcap_digi_args["ResolutionT"],  # ns

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -60,7 +60,7 @@ runMuon = opts.includeMuon                          # if false, it will not digi
 addNoise = opts.addNoise                            # add noise or not to the cell energy
 addCrosstalk = opts.addCrosstalk                    # switch on/off the crosstalk
 addTracks = opts.addTracks                          # add tracks or not
-digitizeTrackerHits = opts.runTrkHitDigitization    # digitize tracker hits (DDPlanarDigi as default)
+runTrkHitDigitization = opts.runTrkHitDigitization    # digitize tracker hits (DDPlanarDigi as default)
 useLegacyVTXDigitizer = opts.useLegacyVTXDigitizer   # digitize tracker hits (VTXdigitizer, smear truth)
 runTrkFinder = opts.runTrkFinder                    # run GGTF on digitized tracker hits
 
@@ -226,7 +226,7 @@ io_svc.Input = inputfile
 io_svc.Output = outputfile
 ExtSvc += [EventDataSvc("EventDataSvc")]
 
-if addTracks or digitizeTrackerHits or addNoise:
+if addTracks or runTrkHitDigitization or addNoise:
     ExtSvc += ["RndmGenSvc"]
 
 
@@ -268,7 +268,7 @@ if addTracks:
 
 
 # Tracker digitisation
-if digitizeTrackerHits:
+if runTrkHitDigitization:
     import math
     # different sensors for inner/outer barrel layers
     # see https://indico.cern.ch/event/1244371/contributions/5350233
@@ -353,8 +353,8 @@ if digitizeTrackerHits:
                                       outputSimDigiAssociation= vxd_endcap_digi_args["SimTrkHitRelCollection"][0],
                                       detectorName=vxd_endcap_digi_args["SubDetectorName"],
                                       readoutName=vxd_endcap_digi_args["SimTrkHitRelCollection"][0],
-                                      xResolution=vxd_endcap_digi_args["ResolutionU"],  # mm, r-phi direction
-                                      yResolution=vxd_endcap_digi_args["ResolutionV"],  # mm, z direction
+                                      xResolution=vxd_endcap_digi_args["ResolutionU"],  # mm, r direction
+                                      yResolution=vxd_endcap_digi_args["ResolutionV"],  # mm, phi direction
                                       tResolution=vxd_endcap_digi_args["ResolutionT"],  # ns
                                       forceHitsOntoSurface=False,
                                       OutputLevel=INFO
@@ -381,8 +381,8 @@ if digitizeTrackerHits:
                                        outputSimDigiAssociation= siWr_endcap_digi_args["SimTrkHitRelCollection"][0],
                                        detectorName=siWr_endcap_digi_args["SubDetectorName"],
                                        readoutName=siWr_endcap_digi_args["SimTrkHitRelCollection"][0],
-                                       xResolution=siWr_endcap_digi_args["ResolutionU"],  # mm, r-phi direction
-                                       yResolution=siWr_endcap_digi_args["ResolutionV"],  # mm, z direction
+                                       xResolution=siWr_endcap_digi_args["ResolutionU"],  # mm, r direction
+                                       yResolution=siWr_endcap_digi_args["ResolutionV"],  # mm, phi direction
                                        tResolution=siWr_endcap_digi_args["ResolutionT"],  # ns
                                        forceHitsOntoSurface=False,
                                        OutputLevel=INFO
@@ -442,7 +442,7 @@ if digitizeTrackerHits:
 
 if runTrkFinder:
     # Run consistency checks first
-    if not digitizeTrackerHits:
+    if not runTrkHitDigitization:
         raise RuntimeError("To run the track finder, the tracker hits digitization must be enabled.")
     if useLegacyVTXDigitizer:
         raise RuntimeError("The track finder requires DDPlanarDigi digitization of silicon detector hits.")

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -18,11 +18,10 @@ from GaudiKernel.PhysicalConstants import pi
 inputfile = "ALLEGRO_sim.root"             # input file produced with ddsim - can be overridden with IOSvc.Input
 outputfile = "ALLEGRO_sim_digi_reco.root"  # output file produced by this steering file - can be overridden with IOSvc.Output
 Nevts = -1                                 # -1 means all events in input file (can be overridden with -n or --num-events option of k4run
+dataFolderDef = "./"                       # directory containing the calibration files
 
 # - general settings not set via CLI
 filterNoiseThreshold = -1                  # if addNoise is true, and filterNoiseThreshold is >0, will filter away cells with abs(energy) below filterNoiseThreshold * expected sigma(noise)
-# dataFolder = "data/"                     # directory containing the calibration files
-dataFolder = "./"                          # directory containing the calibration files
 
 # - general settings set via CLI
 from k4FWCore.parseArgs import parser
@@ -36,6 +35,7 @@ def str2bool(v):
     else:
         raise argparse.ArgumentTypeError("Boolean value expected.")
 
+parser.add_argument("--dataFolder", type=str, help="Path to calibration data folder", default=dataFolderDef)
 parser.add_argument("--includeHCal", type=str2bool, nargs="?", help="Also digitize HCal hits and create ECAL+HCAL clusters", const=True, default=False)
 parser.add_argument("--includeMuon", type=str2bool, nargs="?", help="Also digitize muon hits", const=True, default=False)
 parser.add_argument("--saveHits", type=str2bool, nargs="?", help="Save G4 hits", const=True, default=False)
@@ -53,6 +53,7 @@ parser.add_argument("--runTrkHitDigitization", type=str2bool, nargs="?", help="D
 parser.add_argument("--useLegacyVTXDigitizer", type=str2bool, nargs="?", help="Perform VTXdigitizer-based digitisation of tracker hits", const=True, default=False)
 
 opts = parser.parse_known_args()[0]
+dataFolder = opts.dataFolder                        # directory containing the calibration files
 runHCal = opts.includeHCal                          # if false, it will produce only ECAL clusters. if true, it will also produce ECAL+HCAL clusters
 runMuon = opts.includeMuon                          # if false, it will not digitize muon hits
 addNoise = opts.addNoise                            # add noise or not to the cell energy

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/README.md
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/README.md
@@ -20,6 +20,7 @@ ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particl
 ```
 # First get the data needed for the DCH cluster counting parametrization (still work in progress)
 wget --no-clobber https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/DataAlgFORGEANT.root
+wget --no-clobber https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/IDEA_o1_v03/SimpleGatrIDEAv3o1.onnx
 k4run run_digi_reco.py
 # you can then print the rootfile content with
 podio-dump IDEA_sim_digi_reco.root  

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/ctest_sim_digi_reco.sh
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/ctest_sim_digi_reco.sh
@@ -15,7 +15,10 @@ ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particl
 
 # download file for cluster counting technique
 DCHfilename="https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/DataAlgFORGEANT.root"
+GGTFmodel="https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/IDEA_o1_v03/SimpleGatrIDEAv3o1.onnx"
+
 wget --no-clobber $DCHfilename
+wget --no-clobber $GGTFmodel
 
 # run the DIGI/RECO step
 k4run $SCRIPT_DIR/run_digi_reco.py

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -156,7 +156,7 @@ from Configurables import GGTF_tracking
 
 GGTF = GGTF_tracking(
     "GGTF_tracking",
-    InputPlanarHitCollections=["VTXBDigis", "VTXDDigis"],  # "SiWrDDigis", "SiWrBDigis" not working yet
+    InputPlanarHitCollections=["VTXBDigis", "VTXDDigis", "SiWrDDigis", "SiWrBDigis"],
     InputWireHitCollections=["DCH_DigiCollection"],
     OutputTracksGGTF=["CDCHTracks"],
     ModelPath="SimpleGatrIDEAv3o1.onnx",

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -149,6 +149,22 @@ dNdxFromTracks = TrackdNdxDelphesBased("dNdxFromTracks",
                                   FillFactor=1.0,
                                   OutputLevel=ERROR)
 
+
+# Load the Geometric Graph Track Finder (GGTF), following example from:
+# k4RecTracker/Tracking/test/testTrackFinder/runTestTrackFinder.py
+from Configurables import GGTF_tracking
+
+GGTF = GGTF_tracking(
+    "GGTF_tracking",
+    InputPlanarHitCollections=["VTXBDigis", "VTXDDigis"],  # "SiWrDDigis", "SiWrBDigis" not working yet
+    InputWireHitCollections=["DCH_DigiCollection"],
+    OutputTracksGGTF=["CDCHTracks"],
+    ModelPath="SimpleGatrIDEAv3o1.onnx",
+    Tbeta=0.6,    # default clustering parameters
+    Td=0.3,       # form the example in k4RecTracker
+    OutputLevel=INFO,
+)
+
 ################ Dual-readout calorimeter
 # SiPM emulation
 from Configurables import SimulateSiPMwithEdep
@@ -337,6 +353,7 @@ application_mgr = ApplicationMgr(
         tracksFromGenParticles,
         plotTrackDCHHitDistances,
         dNdxFromTracks,
+        GGTF,
         sipmEdep,
         sipmOptical,
         topoClusterAll,


### PR DESCRIPTION
Schedule the Geometric Graph Track Finding algorithm for the IDEA_o1_v03 and ALLEGRO_o1_v03 reconstructions.
* Update digitizers for SiWr to `DDPlanarDigi`
* Add time resolution

Additionally, adds option in ALLEGRO script to specify the path where the files needed for digitization and reco steps are. In this way, if eos access is available, there's no need to copy files around.