### PR TITLE
Change workflow to use the nightlies instead of the LCG stacks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,122 @@ on:
   schedule:
         - cron: '16 5 * * *'
 
-
 jobs:
   build:
-    strategy:
-      matrix:
-        build_type: ["nightly"]
-        image: ["alma9"]
-      fail-fast: false
     runs-on: ubuntu-latest
+
+    env:
+      IMAGE: alma9
+
     steps:
-    - uses: actions/checkout@v4
-    - uses: key4hep/key4hep-actions/key4hep-build@main
-      with:
-        build_type: ${{ matrix.build_type }}
-        image: ${{ matrix.image }}
+      - uses: actions/checkout@v4
+
+      - name: Set date
+        shell: bash
+        run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Start alma9 container
+        shell: bash
+        run: |
+          name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+          docker run --name container --privileged -v ${GITHUB_WORKSPACE}:/${name} -v ~/.cache/ccache:/root/.cache/ccache -d ghcr.io/key4hep/key4hep-images/alma9-cvmfs tail -f /dev/null
+
+      - name: Setup environment and build
+        shell: bash
+        run: |
+          name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+          cat <<'EOF' > ${GITHUB_WORKSPACE}/script_container.sh
+          set -e
+
+          export CCACHE_DIR=/root/.cache/ccache
+          export CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime
+          ccache --set-config=max_size=500M
+          ccache -z
+
+          name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+
+          if [ -x "$(command -v mold)" ]; then
+            rm /usr/bin/ld
+            ln -s /usr/bin/mold /usr/bin/ld
+            echo "Using the mold linker"
+          fi
+
+          source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+
+          if [[ "$KEY4HEP_STACK" == *"hsf.org"* ]]; then
+            if command -v mold &>/dev/null; then
+              mimalloc=$(echo $(dirname $(dirname $(dirname $(dirname $(which mold)))))/mimalloc/*/lib*/libmimalloc.so)
+            fi
+          else
+            mimalloc_found=""
+            IFS=: read -ra dirs <<< "$LD_LIBRARY_PATH"
+            for dir in "${dirs[@]}"; do
+              candidate="$dir/libmimalloc.so"
+              if [ -f "$candidate" ]; then
+                mimalloc_found="$candidate"
+                break
+              fi
+            done
+            mimalloc="$mimalloc_found"
+          fi
+          if [ -f "$mimalloc" ]; then
+            export LD_PRELOAD=$mimalloc
+            echo "Using mimalloc: $mimalloc"
+          else
+            echo "mimalloc not found, using default allocator"
+          fi
+
+          cd /${name}
+
+          if command -v k4_local_repo >/dev/null 2>&1; then
+            k4_local_repo
+          fi
+          mkdir -p build
+          cd build
+
+          if [ -f /${name}/.github/workflows/.key4hep-build-env ]; then
+            echo "Sourcing .keyhep-build-env"
+            echo "----------------------------------"
+            cat /${name}/.github/workflows/.key4hep-build-env
+            echo "----------------------------------"
+            source /${name}/.github/workflows/.key4hep-build-env
+          fi
+
+          set -x
+          cmake .. \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_FLAGS="-Werror -Wno-error=cpp -Wno-error=deprecated-declarations" \
+            -G Ninja \
+            ${K4_CMAKE_EXTRA_ARGS}
+          set +x
+
+          time ninja -k0 install
+          ccache -s
+
+          if [[ $KEY4HEP_STACK == *"devkey"* ]]; then
+            export PATH=/${name}/install/bin:$PATH
+            export LD_LIBRARY_PATH=/${name}/install/lib:${name}/install/lib64:$LD_LIBRARY_PATH
+            export ROOT_INCLUDE_PATH=/${name}/install/include:$ROOT_INCLUDE_PATH
+            export CPATH=/${name}/install/include:$CPATH
+            export PYTHONPATH=/${name}/install/lib/python*/site-packages:/${name}/install/python:$PYTHONPATH
+          fi
+
+          ctest -j $(nproc) --output-on-failure
+          EOF
+
+          chmod +x ${GITHUB_WORKSPACE}/script_container.sh
+
+          docker exec container /bin/bash -c "/mount.sh && /${name}/script_container.sh"
+
+      - name: Upload FCC-config file
+        if: github.repository == 'HEP-FCC/FCC-config'
+        uses: actions/upload-artifact@v6
+        with:
+          name: ALLEGRO and IDEA sim-digi-reco files
+          path: |
+            ${{ github.workspace }}/build/ALLEGRO_sim_digi_reco.root
+            ${{ github.workspace }}/build/IDEA_sim_digi_reco.root
+          retention-days: 7
+          overwrite: true


### PR DESCRIPTION
Note that this will be broken anyways when the version of onnxruntime is updated since, now the tests are failing because of that. It just happens that the LCG stacks have a slightly new version where the GGTF tracking crashes. I just basically copied what's in the `key4hep-build` action but hardcoding the nightlies, we can change this later, or if we forget it will stop working at some point.