### PR TITLE
Fix finding test scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,6 @@ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/FCCee/ DESTINATION ${CMAKE_INSTALL_D
 
 # TESTING
 include(CTest)
-add_test(NAME ALLEGRO_o1_v03 COMMAND ../FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/ctest_sim_digi_reco.sh)
-add_test(NAME IDEA_o1_v03 COMMAND ../FCCee/FullSim/IDEA/IDEA_o1_v03/ctest_sim_digi_reco.sh)
+add_test(NAME ALLEGRO_o1_v03 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/ctest_sim_digi_reco.sh)
+add_test(NAME IDEA_o1_v03 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/FCCee/FullSim/IDEA/IDEA_o1_v03/ctest_sim_digi_reco.sh)
 set_tests_properties(ALLEGRO_o1_v03 PROPERTIES TIMEOUT 1800) # 30 minutes


### PR DESCRIPTION
Look for test scripts starting from ${CMAKE_CURRENT_SOURCE_DIR}, not .. . (Don't make assumptions about the location of the build directory.)