### PR TITLE
[Full Sim] Improve consistency between particle gun and physics events

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/README.md
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/README.md
@@ -12,7 +12,7 @@ cd FCC-config/FCCee/FullSim/IDEA/IDEA_o1_v03/
 
 ## Running the simulation
 ```
-ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --numberOfEvents 10 --outputFile IDEA_sim.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml --steeringFile SteeringFile_IDEA_o1_v03.py
+ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --crossingAngleBoost 0 --numberOfEvents 10 --outputFile IDEA_sim.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml --steeringFile SteeringFile_IDEA_o1_v03.py
 ```
 (if you're not interested in calorimeter hits but only the material, you can set `simulateCalo = False` to speed up)
 

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/SteeringFile_IDEA_o1_v03.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/SteeringFile_IDEA_o1_v03.py
@@ -15,7 +15,7 @@ SIM.crossingAngleBoost = 0.015
 SIM.enableDetailedShowerMode = False
 SIM.enableG4GPS = False
 SIM.enableG4Gun = False
-SIM.enableGun = True
+SIM.enableGun = False
 ## InputFiles for simulation .stdhep, .slcio, .HEPEvt, .hepevt, .pairs, .hepmc, .hepmc.gz, .hepmc.xz, .hepmc.bz2, .hepmc3, .hepmc3.gz, .hepmc3.xz, .hepmc3.bz2, .hepmc3.tree.root files are supported
 SIM.inputFiles = []
 ## Macro file to execute for runType 'run' or 'vis'

--- a/FCCee/FullSim/IDEA/IDEA_o2_v01/README.md
+++ b/FCCee/FullSim/IDEA/IDEA_o2_v01/README.md
@@ -17,7 +17,7 @@ cd FCC-config/FCCee/FullSim/IDEA/IDEA_o2_v01/
 It is recommended to run the simulation with the `Steering File` provided here because it associates sensitive actions to calorimeters as intended by the developers.
 
 ```
-ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --crossingAngleBoost 0 --numberOfEvents 10 --outputFile IDEA_sim.root --random.enableEventSeed --random.seed 42 --outputFile IDEA_sim.root --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml --steeringFile SteeringFile_IDEA_o2_v01.py
+ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --crossingAngleBoost 0 --numberOfEvents 10 --random.enableEventSeed --random.seed 42 --outputFile IDEA_sim.root --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml --steeringFile SteeringFile_IDEA_o2_v01.py
 ```
 
 ## Running the digitization and reconstruction

--- a/FCCee/FullSim/IDEA/IDEA_o2_v01/README.md
+++ b/FCCee/FullSim/IDEA/IDEA_o2_v01/README.md
@@ -17,7 +17,7 @@ cd FCC-config/FCCee/FullSim/IDEA/IDEA_o2_v01/
 It is recommended to run the simulation with the `Steering File` provided here because it associates sensitive actions to calorimeters as intended by the developers.
 
 ```
-ddsim --outputFile IDEA_o2_sim.root --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml --steeringFile SteeringFile_IDEA_o2_v01.py
+ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --crossingAngleBoost 0 --numberOfEvents 10 --outputFile IDEA_sim.root --random.enableEventSeed --random.seed 42 --outputFile IDEA_sim.root --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml --steeringFile SteeringFile_IDEA_o2_v01.py
 ```
 
 ## Running the digitization and reconstruction

--- a/FCCee/FullSim/IDEA/IDEA_o2_v01/SteeringFile_IDEA_o2_v01.py
+++ b/FCCee/FullSim/IDEA/IDEA_o2_v01/SteeringFile_IDEA_o2_v01.py
@@ -6,11 +6,11 @@ SIM = DD4hepSimulation()
 ## The compact XML file, or multiple compact files, if the last one is the closer.
 SIM.compactFile = ["../FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml"]
 ## Lorentz boost for the crossing angle, in radian!
-SIM.crossingAngleBoost = 0.0
+SIM.crossingAngleBoost = 0.015
 SIM.enableDetailedShowerMode = False
 SIM.enableG4GPS = False
 SIM.enableG4Gun = False
-SIM.enableGun = True
+SIM.enableGun = False
 ## InputFiles for simulation .stdhep, .slcio, .HEPEvt, .hepevt, .pairs, .hepmc, .hepmc.gz, .hepmc.xz, .hepmc.bz2, .hepmc3, .hepmc3.gz, .hepmc3.xz, .hepmc3.bz2, .hepmc3.tree.root files are supported
 SIM.inputFiles = []
 ## Macro file to execute for runType 'run' or 'vis'


### PR DESCRIPTION
- When running with an input file, the steering file was adding a particle gun on top. Fixing it here now while waiting for a fix upstream. Thanks for spotting this @jeyserma ! 
- Take this opportunity to also explicitly set the transverse boost to 0 in the example particle gun command