### PR TITLE
Fixing DDPlanar digitisation in new vertex/silicon wrapper

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -294,6 +294,7 @@ if runTrkHitDigitization:
         "SimTrkHitRelCollection": ["VTXBSimDigiLinks"],
         "SubDetectorName": "VertexBarrel",
         "TrackerHitCollectionName": ["VTXBDigis"],
+        "CellIDBits": 32,
     }
 
     vxd_endcap_digi_args = {
@@ -305,6 +306,7 @@ if runTrkHitDigitization:
         "SimTrkHitRelCollection": ["VTXDSimDigiLinks"],
         "SubDetectorName": "VertexDisks",
         "TrackerHitCollectionName": ["VTXDDigis"],
+        "CellIDBits": 32,
     }
 
     siWr_barrel_digi_args = {
@@ -316,6 +318,7 @@ if runTrkHitDigitization:
         "SimTrkHitRelCollection": ["SiWrBSimDigiLinks"],
         "SubDetectorName": "SiWrB",
         "TrackerHitCollectionName": ["SiWrBDigis"],
+        "CellIDBits": 32,
     }
 
     siWr_endcap_digi_args = {
@@ -327,6 +330,7 @@ if runTrkHitDigitization:
         "SimTrkHitRelCollection": ["SiWrDSimDigiLinks"],
         "SubDetectorName": "SiWrD",
         "TrackerHitCollectionName": ["SiWrDDigis"],
+        "CellIDBits": 32,
     }
 
 

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -450,7 +450,7 @@ if runTrkFinder:
 
     # Load the GGTF, following example from:
     # k4RecTracker/Tracking/test/testTrackFinder/runTestTrackFinder.py
-    from Configurables import GGTF_tracking
+    from Configurables import GGTFTrackFinder
 
     modelPath = dataFolder + "SimpleGatrIDEAv3o1.onnx"   #FIXME: update to ALLEGRO-trained model when available
 
@@ -458,8 +458,8 @@ if runTrkFinder:
     tbeta = 0.6     # tbeta clustering parameter
     td = 0.3        # td clustering parameter
 
-    GGTF = GGTF_tracking(
-        "GGTF_tracking",
+    GGTF = GGTFTrackFinder(
+        "GGTFTrackFinder",
         InputPlanarHitCollections=["VTXBDigis", "VTXDDigis", "SiWrDDigis", "SiWrBDigis"],
         InputWireHitCollections=["DCH_DigiCollection"],
         OutputTracksGGTF=["CDCHTracks"],


### PR DESCRIPTION
Since there is [pixel segmentation in the vertex and silicon wrapper](https://github.com/key4hep/k4geo/blob/d197ae2a6288e3e92b6eab7b4924ded615a88606/FCCee/IDEA/compact/IDEA_o1_v04/VertexComplete_o1_v04.xml#L474) now for ALLEGRO_o1_v03 (and also ALLEGRO_o2_v01, IDEA_o1_v04 and IDEA_o2_v01) one now needs to specify to only use the first 32 cellID bits, since the next 32 bits are used for the pixel information. Otherwise DDPlanar fails to digitise the hits (see [here](https://github.com/HEP-FCC/FCC-config/actions/runs/25043443779/job/73352257740?pr=336#step:3:12420)).

Let me know if something else should be changed @BrieucF 