### PR TITLE
[FullSim] Rename track related collections

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -438,8 +438,8 @@ if runTrkHitDigitization:
     dch_digitizer = DCHdigi_v02(
         "DCHdigi2",
         InputSimHitCollection=["DCHCollection"],
-        OutputDigihitCollection = ["DCH_DigiCollection"],
-        OutputLinkCollection = ["DCH_DigiSimAssociationCollection"],
+        OutputDigihitCollection = ["DCHDigis"],
+        OutputLinkCollection = ["DCHDigisSimAssociationCollection"],
         DCH_name="DCH_v2",
         zResolution_mm = 30.,               # in mm
         xyResolution_mm = 0.1,              # in mm
@@ -473,8 +473,8 @@ if runTrkFinder:
     trackFinder = GGTFTrackFinder(
         "GGTFTrackFinder",
         InputPlanarHitCollections=["VTXBDigis", "VTXDDigis", "SiWrDDigis", "SiWrBDigis"],
-        InputWireHitCollections=["DCH_DigiCollection"],
-        OutputTracksGGTF=["CDCHTracks"],
+        InputWireHitCollections=["DCHDigis"],
+        OutputTracksGGTF=["PrefitTracks"],
         ModelPath=modelPath,
         Tbeta=tbeta,    # default clustering parameters
         Td=td,       # form the example in k4RecTracker
@@ -490,9 +490,9 @@ if runTrkFitter:
 
     trackFitter = GenfitTrackFitter(
         "GenfitTrackFitter",
-        
-        InputTracks=["CDCHTracks"],
-        OutputFittedTracks=["CDCHFittedTracks"],
+        InputTracks=["PrefitTracks"],
+        OutputFittedTracks=["FittedTracks"],
+        OutputFittedTracksWithFilteredHits=["FittedTracksWithFilteredHits"],
         RunSingleEvaluation = True,
         UseBrems = True,
         BetaInit = 100,

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/run_digi_reco.py
@@ -89,8 +89,8 @@ from Configurables import DCHdigi_v02
 dch_digitizer = DCHdigi_v02(
     "DCHdigi2",
     InputSimHitCollection=["DCHCollection"],
-    OutputDigihitCollection = ["DCH_DigiCollection"],
-    OutputLinkCollection = ["DCH_DigiSimAssociationCollection"],
+    OutputDigihitCollection = ["DCHDigis"],
+    OutputLinkCollection = ["DCHDigisSimAssociationCollection"],
     DCH_name="DCH_v2",
     zResolution_mm = 30.,               # in mm
     xyResolution_mm = 0.1,              # in mm
@@ -171,8 +171,8 @@ absolute_path = os.path.abspath(filename)
 trackFinder = GGTFTrackFinder(
     "GGTFTrackFinder",
     InputPlanarHitCollections=["VTXBDigis", "VTXDDigis", "SiWrDDigis", "SiWrBDigis"],
-    InputWireHitCollections=["DCH_DigiCollection"],
-    OutputTracksGGTF=["CDCHTracks"],
+    InputWireHitCollections=["DCHDigis"],
+    OutputTracksGGTF=["PrefitTracks"],
     ModelPath=absolute_path,
     Tbeta=0.6,    # default clustering parameters
     Td=0.3,       # form the example in k4RecTracker
@@ -186,8 +186,9 @@ from Configurables import GenfitTrackFitter
 trackFitter = GenfitTrackFitter(
     "GenfitTrackFitter",
     
-    InputTracks=["CDCHTracks"],
-    OutputFittedTracks=["CDCHFittedTracks"],
+    InputTracks=["PrefitTracks"],
+    OutputFittedTracks=["FittedTracks"],
+    OutputFittedTracksWithFilteredHits=["FittedTracksWithFilteredHits"],
     RunSingleEvaluation = True,
     UseBrems = True,
     BetaInit = 100,


### PR DESCRIPTION
Here is a proposal to make the name of the track collections more explicit. I also renamed `DCH_DigiCollection` to align it better with the other digi collections. This is a breaking change that we will have to propagate but the usage of `DCH_DigiCollection` is still quite minor at this stage.