### PR TITLE
Configure indexing service for ALLEGRO.

### DIFF
--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -535,6 +535,38 @@ else:
     hcalBarrelReadoutName = ""
     hcalEndcapReadoutName = ""
 
+# - Configure geometry tools and indexing service.
+geotools = []
+from Configurables import TubeLayerModuleThetaCaloTool
+ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
+                                                      readoutName=ecalBarrelReadoutName,
+                                                      activeVolumeName="LAr_sensitive",
+                                                      activeFieldName="layer",
+                                                      activeVolumesNumber=ecalBarrelLayers,
+                                                      fieldNames=["system"],
+                                                      fieldValues=[IDs["ECAL_Barrel"]],
+                                                      OutputLevel=INFO)
+geotools += [ecalBarrelGeometryTool]
+
+from Configurables import TurbineEndcapCaloTool
+ecalEndcapGeometryTool = TurbineEndcapCaloTool ("ecalEndcapGeometryTool",
+                                                readoutName=ecalEndcapReadoutName)
+geotools += [ecalEndcapGeometryTool]
+
+if runHCal:
+    from Configurables import HCalPhiThetaCaloTool
+    hcalBarrelGeometryTool = HCalPhiThetaCaloTool ("hcalBarrelGeometryTool",
+                                                   readoutName=hcalBarrelReadoutName)
+    geotools += [hcalBarrelGeometryTool]
+    hcalEndcapGeometryTool = HCalPhiThetaCaloTool ("hcalEndcapGeometryTool",
+                                                   readoutName=hcalEndcapReadoutName)
+    geotools += [hcalEndcapGeometryTool]
+    
+
+from Configurables import k4__recCalo__CaloCellIndexerSvc
+ExtSvc += [k4__recCalo__CaloCellIndexerSvc (GeoTools = geotools)]
+
+
 # - EM scale calibration (sampling fraction)
 from Configurables import CalibrateInLayersTool
 #   * ECAL barrel

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -668,16 +668,6 @@ if addNoise:
         OutputLevel=INFO
     )
 
-    from Configurables import TubeLayerModuleThetaCaloTool
-    ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
-                                                          readoutName=ecalBarrelReadoutName,
-                                                          activeVolumeName="LAr_sensitive",
-                                                          activeFieldName="layer",
-                                                          activeVolumesNumber=ecalBarrelLayers,
-                                                          fieldNames=["system"],
-                                                          fieldValues=[IDs["ECAL_Barrel"]],
-                                                          OutputLevel=INFO)
-
     ecalEndcapNoisePath = dataFolder + "elecNoise_ecalendcap.root"
     ecalEndcapNoiseRMSHistName = "noise_endcap_wheel"
     from Configurables import NoiseCaloCellsFromFileTurbineEndcapTool
@@ -695,10 +685,6 @@ if addNoise:
                                                                   scaleFactor=1 / 1000.,  # MeV to GeV
                                                                   OutputLevel=INFO)
 
-    from Configurables import TurbineEndcapCaloTool
-    ecalEndcapGeometryTool = TurbineEndcapCaloTool("ecalEndcapGeometryTool",
-                                                   readoutName=ecalEndcapReadoutName,
-                                                   OutputLevel=INFO)
 else:
     ecalBarrelNoiseTool = None
     ecalBarrelGeometryTool = None

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o2_v01/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o2_v01/run_digi_reco.py
@@ -670,15 +670,6 @@ if addNoise:
         OutputLevel=INFO
     )
 
-    from Configurables import TubeLayerModuleThetaCaloTool
-    ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
-                                                          readoutName=ecalBarrelReadoutName,
-                                                          activeVolumeName="LAr_sensitive",
-                                                          activeFieldName="layer",
-                                                          activeVolumesNumber=ecalBarrelLayers,
-                                                          fieldNames=["system"],
-                                                          fieldValues=[IDs["ECAL_Barrel"]],
-                                                          OutputLevel=INFO)
 
     ecalEndcapNoisePath = dataFolder + "elecNoise_ecalendcap.root"
     ecalEndcapNoiseRMSHistName = "noise_endcap_wheel"
@@ -697,10 +688,6 @@ if addNoise:
                                                                   scaleFactor=1 / 1000.,  # MeV to GeV
                                                                   OutputLevel=INFO)
 
-    from Configurables import TurbineEndcapCaloTool
-    ecalEndcapGeometryTool = TurbineEndcapCaloTool("ecalEndcapGeometryTool",
-                                                   readoutName=ecalEndcapReadoutName,
-                                                   OutputLevel=INFO)
 else:
     ecalBarrelNoiseTool = None
     ecalBarrelGeometryTool = None

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o2_v01/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o2_v01/run_digi_reco.py
@@ -537,6 +537,38 @@ else:
     hcalBarrelReadoutName = ""
     hcalEndcapReadoutName = ""
 
+# - Configure geometry tools and indexing service.
+geotools = []
+from Configurables import TubeLayerModuleThetaCaloTool
+ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
+                                                      readoutName=ecalBarrelReadoutName,
+                                                      activeVolumeName="LAr_sensitive",
+                                                      activeFieldName="layer",
+                                                      activeVolumesNumber=ecalBarrelLayers,
+                                                      fieldNames=["system"],
+                                                      fieldValues=[IDs["ECAL_Barrel"]],
+                                                      OutputLevel=INFO)
+geotools += [ecalBarrelGeometryTool]
+
+from Configurables import TurbineEndcapCaloTool
+ecalEndcapGeometryTool = TurbineEndcapCaloTool ("ecalEndcapGeometryTool",
+                                                readoutName=ecalEndcapReadoutName)
+geotools += [ecalEndcapGeometryTool]
+
+if runHCal:
+    from Configurables import HCalPhiThetaCaloTool
+    hcalBarrelGeometryTool = HCalPhiThetaCaloTool ("hcalBarrelGeometryTool",
+                                                   readoutName=hcalBarrelReadoutName)
+    geotools += [hcalBarrelGeometryTool]
+    hcalEndcapGeometryTool = HCalPhiThetaCaloTool ("hcalEndcapGeometryTool",
+                                                   readoutName=hcalEndcapReadoutName)
+    geotools += [hcalEndcapGeometryTool]
+    
+
+from Configurables import k4__recCalo__CaloCellIndexerSvc
+ExtSvc += [k4__recCalo__CaloCellIndexerSvc (GeoTools = geotools)]
+
+
 # - EM scale calibration (sampling fraction)
 from Configurables import CalibrateInLayersTool
 #   * ECAL barrel


### PR DESCRIPTION
Configure the indexing service with ECal and HCal for ALLEGRO.

To enable performance improvements in calorimeter tools relying on the indexing service.
