### PR TITLE
Allow skipping the DR calorimeter SD setup from the command line

### DIFF
--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/README.md
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/README.md
@@ -14,7 +14,9 @@ cd FCC-config/FCCee/FullSim/IDEA/IDEA_o1_v03/
 ```
 ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --crossingAngleBoost 0 --numberOfEvents 10 --outputFile IDEA_sim.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml --steeringFile SteeringFile_IDEA_o1_v03.py
 ```
-(if you're not interested in calorimeter hits but only the material, you can set `simulateCalo = False` to speed up)
+(if you're not interested in calorimeter hits but only the material, you can set `simulateDRCalo = False` to speed up, or pass `--no-simulateDRCalo` on the command line — the option is defined by the steering file itself, so it does not appear in `ddsim --help`)
+
+`--no-simulateDRCalo` is also required whenever `DRcalo` is missing from the compact file: its `regexSensitiveDetector` configuration resolves the subdetector by name and ddsim aborts if it is absent.
 
 ## Running the digitization and reconstruction
 ```

--- a/FCCee/FullSim/IDEA/IDEA_o1_v03/SteeringFile_IDEA_o1_v03.py
+++ b/FCCee/FullSim/IDEA/IDEA_o1_v03/SteeringFile_IDEA_o1_v03.py
@@ -1,9 +1,21 @@
+import argparse
+import sys
+
 from DDSim.DD4hepSimulation import DD4hepSimulation
 from g4units import mm, GeV, MeV
 
 ###################################
 # user options
-simulateCalo = True # set to False to skip the calo SD action
+#
+# Also settable on the ddsim command line as --simulateDRCalo / --no-simulateDRCalo.
+# The option is stripped from sys.argv again because ddsim's own parser rejects
+# arguments it does not know.
+_parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+_parser.add_argument("--simulateDRCalo", action=argparse.BooleanOptionalAction, default=True)
+_opts, _rest = _parser.parse_known_args()
+sys.argv = [sys.argv[0]] + _rest
+
+simulateDRCalo = _opts.simulateDRCalo # set to False to skip the calo SD action
 ###################################
 
 SIM = DD4hepSimulation()
@@ -103,7 +115,7 @@ SIM.vertexSigma = [0.0, 0.0, 0.0, 0.0]
 ################################################################################
 
 ##  set the default calorimeter action
-if simulateCalo:
+if simulateDRCalo:
     SIM.action.calo = "Geant4ScintillatorCalorimeterAction"
     ## List of patterns matching sensitive detectors of type Calorimeter.
     SIM.action.calorimeterSDTypes = ["calorimeter", "DRcaloSiPMSD"]
@@ -637,7 +649,7 @@ def setupOpticalPhysics(kernel):
 
     return None
 
-if simulateCalo:
+if simulateDRCalo:
     SIM.physics.setupUserPhysics(setupOpticalPhysics)
 
 def setupDRCFastSim(kernel):

--- a/FCCee/FullSim/IDEA/IDEA_o2_v01/README.md
+++ b/FCCee/FullSim/IDEA/IDEA_o2_v01/README.md
@@ -20,5 +20,12 @@ It is recommended to run the simulation with the `Steering File` provided here b
 ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --crossingAngleBoost 0 --numberOfEvents 10 --random.enableEventSeed --random.seed 42 --outputFile IDEA_sim.root --compactFile $K4GEO/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01.xml --steeringFile SteeringFile_IDEA_o2_v01.py
 ```
 
+The steering file accepts `--no-simulateDRCalo`, which skips the sensitive
+detector setup for `DRBarrelTubes` and `DREndcapTubes`. Pass it whenever those
+subdetectors are missing from the compact file — their `regexSensitiveDetector`
+configuration resolves them by name and ddsim aborts if they are absent. The
+option is defined by the steering file itself, so it does not appear in
+`ddsim --help`.
+
 ## Running the digitization and reconstruction
 This section will be included as soon as the `IDEA_o2` specific digitization code will be merged.

--- a/FCCee/FullSim/IDEA/IDEA_o2_v01/SteeringFile_IDEA_o2_v01.py
+++ b/FCCee/FullSim/IDEA/IDEA_o2_v01/SteeringFile_IDEA_o2_v01.py
@@ -1,5 +1,22 @@
+import argparse
+import sys
+
 from DDSim.DD4hepSimulation import DD4hepSimulation
 from g4units import cm, mm, GeV, MeV
+
+###################################
+# user options
+#
+# Also settable on the ddsim command line as --simulateDRCalo / --no-simulateDRCalo.
+# The option is stripped from sys.argv again because ddsim's own parser rejects
+# arguments it does not know.
+_parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+_parser.add_argument("--simulateDRCalo", action=argparse.BooleanOptionalAction, default=True)
+_opts, _rest = _parser.parse_known_args()
+sys.argv = [sys.argv[0]] + _rest
+
+simulateDRCalo = _opts.simulateDRCalo # set to False to skip the DR tubes SD action
+###################################
 
 SIM = DD4hepSimulation()
 
@@ -113,21 +130,24 @@ SIM.action.mapActions["SCEPCal_TimingLayer"] = "SCEPCal_TimingSDAction"
 SIM.filter.mapDetFilter["SCEPCal_MainLayer"] = ""
 SIM.filter.mapDetFilter["SCEPCal_TimingLayer"] = ""
 
-## Replace SDAction for DREndcapTubes subdetector
-SIM.action.mapActions["DREndcapTubes"] = "DRTubesSDAction"
-## Configure the regexSD for DREndcapTubes subdetector
-SIM.geometry.regexSensitiveDetector["DREndcapTubes"] = {
-    "Match": ["DRETS"],
-    "OutputLevel": 4,
-}
-
-## Replace SDAction for DRBarrelTubes subdetector
-SIM.action.mapActions["DRBarrelTubes"] = "DRTubesSDAction"
-## Configure the regexSD for DRBarrelTubes subdetector
-SIM.geometry.regexSensitiveDetector["DRBarrelTubes"] = {
-    "Match": ["DRBT"],
-    "OutputLevel": 4,
-}
+## Replace SDAction for the DREndcapTubes and DRBarrelTubes subdetectors
+if simulateDRCalo:
+    SIM.action.mapActions["DREndcapTubes"] = "DRTubesSDAction"
+    SIM.action.mapActions["DRBarrelTubes"] = "DRTubesSDAction"
+    ## Configure the regexSD for the two subdetectors
+    SIM.geometry.regexSensitiveDetector["DREndcapTubes"] = {
+        "Match": ["DRETS"],
+        "OutputLevel": 4,
+    }
+    SIM.geometry.regexSensitiveDetector["DRBarrelTubes"] = {
+        "Match": ["DRBT"],
+        "OutputLevel": 4,
+    }
+else:
+    ## Void action so the tubes are also skipped when they are still in the
+    ## geometry; a missing mapActions entry would fall back to SIM.action.calo.
+    SIM.action.mapActions["DREndcapTubes"] = "Geant4VoidSensitiveAction"
+    SIM.action.mapActions["DRBarrelTubes"] = "Geant4VoidSensitiveAction"
 
 ##  set the default run action
 SIM.action.run = []


### PR DESCRIPTION
Closing this — the requirement that motivated it is now solved in k4Bench itself so no change is needed here.

**Context:** k4Bench benchmarks a detector by removing one subdetector at a time from the compact file. Those runs failed with `dd4hep: DetElement::child Unknown child with name: DRcalo`, because `SIM.geometry.regexSensitiveDetector` resolves each key as a `DetElement` and aborts when the subdetector is gone. This PR made that switchable from the command line.

k4Bench now reconciles the steering file with the patched geometry itself (key4hep/k4Bench#110). It works against the steering files unmodified, covers every subdetector and every detector config, and needs nothing kept in sync between the two repos.

Happy to reopen if the command-line options are useful on its own for other purposes.
