### PR TITLE
Introduce ComponentAccumulator-style cell reconstruction for ALLEGRO.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,6 @@ set_tests_properties(ALLEGRO_o1_v03 PROPERTIES TIMEOUT 1800) # 30 minutes
 
 add_test(NAME ComponentAccumulator_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/python/test/ComponentAccumulator_test.py)
 set_tests_properties(ComponentAccumulator_test PROPERTIES FAIL_REGULAR_EXPRESSION failure)
+add_test(NAME DetIDs_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/python/test/DetIDs_test.py)
+
+add_test(NAME ALLEGRO_CreateCaloCellsConfig_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/python/test/ALLEGRO/CreateCaloCellsConfig_test.py)

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o1_v03/run_digi_reco.py
@@ -97,40 +97,12 @@ dropMuonHits = False
 # ECAL barrel parameters for digitization
 # TODO: extract number of layers (for ECAL and HCAL) directly from the detector segmentations
 ecalBarrelLayers = 11
-# e-, 10 GeV, flat theta, B field off
-# ecalBarrelSamplingFraction = [0.3800493723322256] * 1 + [0.13494147915064658] * 1 + [0.142866851721152] * 1 + [0.14839315921940666] * 1 + [0.15298362570665006] * 1 + [0.15709704561942747] * 1 + [0.16063717490147533] * 1 + [0.1641723795419055] * 1 + [0.16845490287689746] * 1 + [0.17111520115997653] * 1 + [0.1730605163148862] * 1
-# e-, 20 GeV, flat theta, B field on
-# LAr+Pb
-ecalBarrelSamplingFraction = [0.3790943904011486] * 1 + [0.1355600584387894] * 1 + [0.14628210607758893] * 1 + [0.15274136994224854] * 1 + [0.15817255837886351] * 1 + [0.16290355087527258] * 1 + [0.1674201708055751] * 1 + [0.1715846423182708] * 1 + [0.17558662106635545] * 1 + [0.18002243792463576] * 1 + [0.18288329976007917] * 1
-# LKr+W
-# ecalBarrelSamplingFraction = [0.4806159038189229, 0.2822724529941907, 0.29324811578621524, 0.2996356722403102, 0.3047116566166906, 0.3090324459212472, 0.3133282052725273, 0.3173868504112048, 0.3215311396527887, 0.32516920330802673, 0.3318488881234955]
-
 ecalBarrelUpstreamParameters = [[0.028158491043365624, -1.564259408365951, -76.52312805346982, 0.7442903558010191, -34.894692961350195, -74.19340877431723]]
 ecalBarrelDownstreamParameters = [[0.00010587711361028165, 0.0052371999097777355, 0.69906696456064, -0.9348243433360095, -0.0364714212117143, 8.360401126995626]]
-if ecalBarrelSamplingFraction and len(ecalBarrelSamplingFraction) > 0:
-    assert (ecalBarrelLayers == len(ecalBarrelSamplingFraction))
-# ECAL endcap parameters for digitization
-# the turbine endcap has calibration "layers" in the both the z and radial
-# directions, for each of the three wheels.  So the total number of layers
-# is given by:
-#
-#   ECalEndcapNumCalibZLayersWheel1*ECalEndcapNumCalibRhoLayersWheel1
-#  +ECalEndcapNumCalibZLayersWheel2*ECalEndcapNumCalibRhoLayersWheel2
-#  +ECalEndcapNumCalibZLayersWheel3*ECalEndcapNumCalibRhoLayersWheel3
-#
-# which in the current design is 5*10+1*14+1*34 = 98
-# NB some cells near the inner and outer edges of the calorimeter are difficult
-# to calibrate as they are not part of the core of well-contained showers.
-# The calibrated values can be <0 or >1 for such cells, so these nonsenical
-# numbers are replaced by 1
 ecalEndcapLayers = 98
-ecalEndcapSamplingFraction = [0.0897818] * 1+ [0.221318] * 1+ [0.0820002] * 1+ [0.994281] * 1+ [0.0414437] * 1+ [0.1148] * 1+ [0.178831] * 1+ [0.142449] * 1+ [0.181206] * 1+ [0.342843] * 1+ [0.137479] * 1+ [0.176479] * 1+ [0.153273] * 1+ [0.195836] * 1+ [0.0780405] * 1+ [0.150202] * 1+ [0.17846] * 1+ [0.164886] * 1+ [0.175758] * 1+ [0.10836] * 1+ [0.160243] * 1+ [0.183373] * 1+ [0.171818] * 1+ [0.194848] * 1+ [0.111899] * 1+ [0.170704] * 1+ [0.188455] * 1+ [0.178164] * 1+ [0.209113] * 1+ [0.105241] * 1+ [0.180637] * 1+ [0.192206] * 1+ [0.186096] * 1+ [0.211962] * 1+ [0.112019] * 1+ [0.180344] * 1+ [0.195684] * 1+ [0.190778] * 1+ [0.218259] * 1+ [0.118516] * 1+ [0.207786] * 1+ [0.204474] * 1+ [0.207048] * 1+ [0.225913] * 1+ [0.111325] * 1+ [0.147875] * 1+ [0.195625] * 1+ [0.173326] * 1+ [0.175449] * 1+ [0.104087] * 1+ [0.153645] * 1+ [0.161263] * 1+ [0.165499] * 1+ [0.171758] * 1+ [0.175789] * 1+ [0.180657] * 1+ [0.184563] * 1+ [0.187876] * 1+ [0.191762] * 1+ [0.19426] * 1+ [0.197959] * 1+ [0.199021] * 1+ [0.204428] * 1+ [0.195709] * 1+ [0.151751] * 1+ [0.171477] * 1+ [0.165509] * 1+ [0.172565] * 1+ [0.172961] * 1+ [0.175534] * 1+ [0.177989] * 1+ [0.18026] * 1+ [0.181898] * 1+ [0.183912] * 1+ [0.185654] * 1+ [0.187515] * 1+ [0.190408] * 1+ [0.188794] * 1+ [0.193699] * 1+ [0.192287] * 1+ [0.19755] * 1+ [0.190943] * 1+ [0.218553] * 1+ [0.161085] * 1+ [0.373086] * 1+ [0.122495] * 1+ [0.21103] * 1+ [1] * 1+ [0.138686] * 1+ [0.0545171] * 1+ [1] * 1+ [1] * 1+ [0.227945] * 1+ [0.0122872] * 1+ [0.00437334] * 1+ [0.00363533] * 1+ [1] * 1+ [1] * 1
-if ecalEndcapSamplingFraction and len(ecalEndcapSamplingFraction) > 0:
-    assert (ecalEndcapLayers == len(ecalEndcapSamplingFraction))
 
 resegmentECalBarrel = False
 
-ecalEndcapWheels = 3
 hcalBarrelLayers = 13
 hcalEndcapLayers = 22
 
@@ -172,6 +144,7 @@ addPi0RecoTool = opts.reconstructPi0s
 #
 TopAlg = []  # alg sequence
 ExtSvc = []  # list of external services
+from FCC_config.ComponentAccumulator import ComponentAccumulator
 
 
 # Event counter
@@ -210,30 +183,19 @@ geoservice.detectors = [
 ]
 ExtSvc += [geoservice]
 
-# retrieve subdetector IDs
-import xml.etree.ElementTree as ET
-tree = ET.parse(path_to_detector + 'DectDimensions.xml')
-root = tree.getroot()
-IDs = {}
-for constant in root.find('define').findall('constant'):
-    if (
-        constant.get('name') == 'DetID_VXD_Barrel'
-        or constant.get('name') == 'DetID_VXD_Disks'
-        or constant.get('name') == 'DetID_DCH'
-        or constant.get('name') == 'DetID_SiWr_Barrel'
-        or constant.get('name') == 'DetID_SiWr_Disks'
-        or constant.get('name') == 'DetID_ECAL_Barrel'
-        or constant.get('name') == 'DetID_ECAL_Endcap'
-        or constant.get('name') == 'DetID_HCAL_Barrel'
-        or constant.get('name') == 'DetID_HCAL_Endcap'
-        or constant.get('name') == 'DetID_Muon_Barrel'
-    ):
-        IDs[constant.get("name")[6:]] = int(constant.get('value'))
-    if (constant.get('name') == 'DetID_Muon_Endcap_1'):
-        IDs[constant.get("name")[6:-2]] = int(constant.get('value'))
-# debug
-print("Subdetector IDs:")
-print(IDs)
+from FCC_config.DetIDs import detIDs
+
+
+# Configuration flags.
+class Flags:
+    pass
+flags = Flags()
+flags.compactFile = geoservice.detectors[0]
+flags.dataFiles = dataFolder
+from FCC_config.ALLEGRO.CreateCaloCellsConfig import defineCaloCellFlags
+defineCaloCellFlags(flags)
+flags.ECal.Barrel.addCrosstalk = addCrosstalk
+
 
 # Input/Output handling
 from k4FWCore import IOSvc
@@ -262,11 +224,12 @@ if addTracks:
                                                     OutputMCRecoTrackParticleAssociation=["TracksFromGenParticlesAssociation"],
                                                     ExtrapolateToECal=True,
                                                     KeepOnlyBestExtrapolation=False,
-                                                    TrackerIDs=[IDs["VXD_Barrel"],
-                                                                IDs["VXD_Disks"],
-                                                                IDs["DCH"],
-                                                                IDs["SiWr_Barrel"],
-                                                                IDs["SiWr_Disks"]],
+                                                    TrackerIDs=detIDs(flags,
+                                                                      ["VXD_Barrel",
+                                                                       "VXD_Disks",
+                                                                       "DCH",
+                                                                       "SiWr_Barrel",
+                                                                       "SiWr_Disks"]),
                                                     OutputLevel=INFO)
     TopAlg += [tracksFromGenParticles]
 
@@ -522,363 +485,87 @@ if runTrkFitter:
 
 # Calorimeter digitization (merging hits into cells, EM scale calibration via sampling fractions)
 
+caldigi_cfg = ComponentAccumulator()
+
 # - ECAL readouts
-ecalBarrelReadoutName = "ECalBarrelModuleThetaMerged"      # barrel, original segmentation (baseline)
 ecalBarrelReadoutName2 = "ECalBarrelModuleThetaMerged2"    # barrel, after re-segmentation (for optimisation studies)
-ecalEndcapReadoutName = "ECalEndcapTurbine"                # endcap, turbine-like (baseline)
-# - HCAL readouts
-if runHCal:
-    hcalBarrelReadoutName = "HCalBarrelReadout"            # barrel, original segmentation (phi-theta)
-    # hcalBarrelReadoutName = "HCalBarrelReadoutPhiRow"    # barrel, alternative segmentation (phi-row)
-    hcalEndcapReadoutName = "HCalEndcapReadout"            # endcap, original segmentation
-else:
-    hcalBarrelReadoutName = ""
-    hcalEndcapReadoutName = ""
-
-# - Configure geometry tools and indexing service.
-geotools = []
-from Configurables import TubeLayerModuleThetaCaloTool
-ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
-                                                      readoutName=ecalBarrelReadoutName,
-                                                      activeVolumeName="LAr_sensitive",
-                                                      activeFieldName="layer",
-                                                      activeVolumesNumber=ecalBarrelLayers,
-                                                      fieldNames=["system"],
-                                                      fieldValues=[IDs["ECAL_Barrel"]],
-                                                      OutputLevel=INFO)
-geotools += [ecalBarrelGeometryTool]
-
-from Configurables import TurbineEndcapCaloTool
-ecalEndcapGeometryTool = TurbineEndcapCaloTool ("ecalEndcapGeometryTool",
-                                                readoutName=ecalEndcapReadoutName)
-geotools += [ecalEndcapGeometryTool]
-
-if runHCal:
-    from Configurables import HCalPhiThetaCaloTool
-    hcalBarrelGeometryTool = HCalPhiThetaCaloTool ("hcalBarrelGeometryTool",
-                                                   readoutName=hcalBarrelReadoutName)
-    geotools += [hcalBarrelGeometryTool]
-    hcalEndcapGeometryTool = HCalPhiThetaCaloTool ("hcalEndcapGeometryTool",
-                                                   readoutName=hcalEndcapReadoutName)
-    geotools += [hcalEndcapGeometryTool]
-    
-
-from Configurables import k4__recCalo__CaloCellIndexerSvc
-ExtSvc += [k4__recCalo__CaloCellIndexerSvc (GeoTools = geotools)]
-
-
-# - EM scale calibration (sampling fraction)
-from Configurables import CalibrateInLayersTool
-#   * ECAL barrel
-calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
-                                        samplingFraction=ecalBarrelSamplingFraction,
-                                        readoutName=ecalBarrelReadoutName,
-                                        layerFieldName="layer")
-#   * ECAL endcap
-calibEcalEndcap = CalibrateInLayersTool("CalibrateECalEndcap",
-                                        samplingFraction=ecalEndcapSamplingFraction,
-                                        readoutName=ecalEndcapReadoutName,
-                                        layerFieldName="layer")
-
-if runHCal:
-    from Configurables import CalibrateCaloHitsTool
-    # HCAL barrel
-    calibHCalBarrel = CalibrateCaloHitsTool(
-        "CalibrateHCalBarrel", invSamplingFraction="29.4202")
-    # HCAL endcap
-    calibHCalEndcap = CalibrateCaloHitsTool(
-        "CalibrateHCalEndcap", invSamplingFraction="29.4202")  # FIXME: to be updated for ddsim
-
-# - cell positioning tools
-from Configurables import CellPositionsECalBarrelModuleThetaSegTool
-cellPositionEcalBarrelTool = CellPositionsECalBarrelModuleThetaSegTool(
-    "CellPositionsECalBarrel",
-    readoutName=ecalBarrelReadoutName,
-    OutputLevel=INFO
-)
-# the noise tool needs the positioning tool, but if I reuse the previous one the code crashes..
-cellPositionEcalBarrelToolForNoise = CellPositionsECalBarrelModuleThetaSegTool(
-    "CellPositionsECalBarrelForNoise",
-    readoutName=ecalBarrelReadoutName,
-    OutputLevel=INFO
-)
-if resegmentECalBarrel:
-    cellPositionEcalBarrelTool2 = CellPositionsECalBarrelModuleThetaSegTool(
-        "CellPositionsECalBarrel2",
-        readoutName=ecalBarrelReadoutName2,
-        OutputLevel=INFO
-    )
-
-from Configurables import CellPositionsECalEndcapTurbineSegTool
-cellPositionEcalEndcapTool = CellPositionsECalEndcapTurbineSegTool(
-    "CellPositionsECalEndcap",
-    readoutName=ecalEndcapReadoutName,
-    OutputLevel=INFO
-)
-cellPositionEcalEndcapToolForNoise = CellPositionsECalEndcapTurbineSegTool(
-    "CellPositionsECalEndcapForNoise",
-    readoutName=ecalEndcapReadoutName,
-    OutputLevel=INFO
-)
-
-if runHCal:
-    from Configurables import CellPositionsHCalPhiThetaSegTool
-    cellPositionHCalBarrelTool = CellPositionsHCalPhiThetaSegTool(
-        "CellPositionsHCalBarrel",
-        readoutName=hcalBarrelReadoutName,
-        detectorName="HCalBarrel",
-        OutputLevel=INFO
-    )
-    cellPositionHCalEndcapTool = CellPositionsHCalPhiThetaSegTool(
-        "CellPositionsHCalEndcap",
-        readoutName=hcalEndcapReadoutName,
-        detectorName="HCalThreePartsEndcap",
-        numLayersHCalThreeParts=[6, 9, 22],
-        OutputLevel=INFO
-    )
-
-# - crosstalk tool
-if addCrosstalk:
-    from Configurables import ReadCaloCrosstalkMap
-    # read the crosstalk map
-    readCrosstalkMap = ReadCaloCrosstalkMap("ReadCrosstalkMap",
-                                            fileName=dataFolder+"xtalk_neighbours_map_ecalB_thetamodulemerged.root",
-                                            OutputLevel=INFO)
-else:
-    readCrosstalkMap = None
-
-# - noise tool
-if addNoise:
-    ecalBarrelNoisePath = dataFolder + "elecNoise_ecalBarrelFCCee_theta.root"
-    ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
-    from Configurables import NoiseCaloCellsFromFileBarrelTool
-    ecalBarrelNoiseTool = NoiseCaloCellsFromFileBarrelTool(
-        "ecalBarrelNoiseTool",
-        cellPositionsTool=cellPositionEcalBarrelToolForNoise,
-        readoutName=ecalBarrelReadoutName,
-        noiseFileName=ecalBarrelNoisePath,
-        elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
-        setNoiseOffset=False,
-        activeFieldName="layer",
-        addPileup=False,
-        filterNoiseThreshold=filterNoiseThreshold,
-        useAbsInFilter=True,
-        numHistograms=ecalBarrelLayers,
-        scaleFactor=1 / 1000.,  # MeV to GeV
-        OutputLevel=INFO
-    )
-
-    ecalEndcapNoisePath = dataFolder + "elecNoise_ecalendcap.root"
-    ecalEndcapNoiseRMSHistName = "noise_endcap_wheel"
-    from Configurables import NoiseCaloCellsFromFileTurbineEndcapTool
-    ecalEndcapNoiseTool = NoiseCaloCellsFromFileTurbineEndcapTool("ecalEndcapNoiseTool",
-                                                                  cellPositionsTool=cellPositionEcalEndcapToolForNoise,
-                                                                  readoutName=ecalEndcapReadoutName,
-                                                                  noiseFileName=ecalEndcapNoisePath,
-                                                                  elecNoiseRMSHistoName=ecalEndcapNoiseRMSHistName,
-                                                                  setNoiseOffset=False,
-                                                                  activeFieldName="wheel",
-                                                                  addPileup=False,
-                                                                  filterNoiseThreshold=filterNoiseThreshold,
-                                                                  useAbsInFilter=True,
-                                                                  numHistograms=ecalEndcapWheels,  # 3 wheels
-                                                                  scaleFactor=1 / 1000.,  # MeV to GeV
-                                                                  OutputLevel=INFO)
-
-else:
-    ecalBarrelNoiseTool = None
-    ecalBarrelGeometryTool = None
-    ecalEndcapNoiseTool = None
-    ecalEndcapGeometryTool = None
+ecalBarrelHitsMergedName = 'ECalBarrelCellsMerged'
+ecalBarrelPositionedCellsName2 = ecalBarrelReadoutName2 + "Positioned"
 
 # Create cells in ECal barrel (calibrated and positioned - optionally with xtalk and noise added)
 # from uncalibrated cells (+cellID info) from ddsim
-ecalBarrelPositionedCellsName = ecalBarrelReadoutName + "Positioned"
-ecalBarrelLinks = ecalBarrelPositionedCellsName + "SimCaloHitLinks"
-from Configurables import CreatePositionedCaloCells
-createEcalBarrelCells = CreatePositionedCaloCells("CreatePositionedECalBarrelCells",
-                                                  doCellCalibration=True,
-                                                  calibTool=calibEcalBarrel,
-                                                  positionsTool=cellPositionEcalBarrelTool,
-                                                  addCrosstalk=addCrosstalk,
-                                                  crosstalkTool=readCrosstalkMap,
-                                                  addCellNoise=False,
-                                                  filterCellNoise=False,
-                                                  noiseTool=None,
-                                                  geometryTool=ecalBarrelGeometryTool,
-                                                  OutputLevel=INFO,
-                                                  hits=ecalBarrelReadoutName,
-                                                  cells=ecalBarrelPositionedCellsName,
-                                                  links=ecalBarrelLinks
-                                                  )
-TopAlg += [createEcalBarrelCells]
+from FCC_config.ALLEGRO.CreateCaloCellsConfig import CreateECalBarrelCellsCfg
+caldigi_cfg.merge(CreateECalBarrelCellsCfg(flags))
 
 # -  now, if we want to also save cells with coarser granularity:
 if resegmentECalBarrel:
     # rewrite the cellId using the merged theta-module segmentation
-    # (merging several modules and severla theta readout cells).
+    # (merging several modules and several theta readout cells).
     # Add noise at this step if you derived the noise already assuming merged cells
     # Step a: compute new cellID of cells based on new readout
     # (merged module-theta segmentation with variable merging vs layer)
-    from Configurables import RedoSegmentation
-    resegmentEcalBarrelTool = RedoSegmentation("ReSegmentationEcal",
-                                               # old bitfield (readout)
-                                               oldReadoutName=ecalBarrelReadoutName,
-                                               # specify which fields are going to be altered (deleted/rewritten)
-                                               oldSegmentationIds=["module", "theta"],
-                                               # new bitfield (readout), with new segmentation (merged modules and theta cells)
-                                               newReadoutName=ecalBarrelReadoutName2,
-                                               OutputLevel=INFO,
-                                               debugPrint=200,
-                                               inhits=ecalBarrelPositionedCellsName,
-                                               outhits="ECalBarrelCellsMerged")
+    # from Configurables import RedoSegmentation
+    from FCC_config.ALLEGRO.CreateCaloCellsConfig import ReSegmentationECalBarrelCfg
+    caldigi_cfg.merge (
+        ReSegmentationECalBarrelCfg(flags,
+                                    newReadoutName = ecalBarrelReadoutName2,
+                                    newCellsName = ecalBarrelHitsMergedName))
 
     # Step b: merge new cells with same cellID together
     # do not apply cell calibration again since cells were already
     # calibrated in Step 1
     # noise and xtalk off assuming they were applied earlier
-    ecalBarrelPositionedCellsName2 = ecalBarrelReadoutName2 + "Positioned"
-    ecalBarrelLinks2 = ecalBarrelPositionedCellsName2 + "SimCaloHitLinks"
-    createEcalBarrelCells2 = CreatePositionedCaloCells("CreatePositionedECalBarrelCells2",
-                                                       doCellCalibration=False,
-                                                       positionsTool=cellPositionEcalBarrelTool2,
-                                                       calibTool=None,
-                                                       crosstalkTool=None,
-                                                       addCrosstalk=False,
-                                                       addCellNoise=False,
-                                                       filterCellNoise=False,
-                                                       OutputLevel=INFO,
-                                                       hits="ECalBarrelCellsMerged",
-                                                       cells=ecalBarrelPositionedCellsName2,
-                                                       links=ecalBarrelLinks2)
-    TopAlg += [
-        resegmentEcalBarrelTool,
-        createEcalBarrelCells2,
-    ]
+    caldigi_cfg.merge (
+        CreateECalBarrelCellsCfg(flags,
+                                 'CreatePositionedECalBarrelCells2',
+                                 hits = ecalBarrelHitsMergedName,
+                                 readoutName=ecalBarrelReadoutName2,
+                                 addCrosstalk = False,
+                                 doCellCalibration = False))
 
 # Create cells in ECal endcap (needed if one wants to apply cell calibration,
 # which is not performed by ddsim)
-ecalEndcapPositionedCellsName = ecalEndcapReadoutName + "Positioned"
-ecalEndcapLinks = ecalEndcapPositionedCellsName + "SimCaloHitLinks"
-createEcalEndcapCells = CreatePositionedCaloCells("CreatePositionedECalEndcapCells",
-                                                  doCellCalibration=True,
-                                                  positionsTool=cellPositionEcalEndcapTool,
-                                                  calibTool=calibEcalEndcap,
-                                                  crosstalkTool=None,
-                                                  addCrosstalk=False,
-                                                  addCellNoise=False,
-                                                  filterCellNoise=False,
-                                                  OutputLevel=INFO,
-                                                  hits=ecalEndcapReadoutName,
-                                                  cells=ecalEndcapPositionedCellsName,
-                                                  links=ecalEndcapLinks)
-TopAlg += [createEcalEndcapCells]
+from FCC_config.ALLEGRO.CreateCaloCellsConfig import CreateECalEndcapCellsCfg
+caldigi_cfg.merge(CreateECalEndcapCellsCfg(flags))
 
 if addNoise:
-    # ecal barrel cells with noise not filtered
-    ecalBarrelCellsNoiseLinks = ecalBarrelPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoise = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoise",
-                                                           doCellCalibration=True,
-                                                           calibTool=calibEcalBarrel,
-                                                           positionsTool=cellPositionEcalBarrelTool,
-                                                           addCrosstalk=addCrosstalk,
-                                                           crosstalkTool=readCrosstalkMap,
-                                                           addCellNoise=True,
-                                                           filterCellNoise=False,
-                                                           noiseTool=ecalBarrelNoiseTool,
-                                                           geometryTool=ecalBarrelGeometryTool,
-                                                           OutputLevel=INFO,
-                                                           hits=ecalBarrelReadoutName,
-                                                           cells=ecalBarrelPositionedCellsName + "WithNoise",
-                                                           links=ecalBarrelCellsNoiseLinks)
-    TopAlg += [createEcalBarrelCellsNoise]
+    # cells with noise not filtered
+    caldigi_cfg.merge(
+        CreateECalBarrelCellsCfg (flags,
+                                  'CreatePositionedECalBarrelCellsWithNoise',
+                                  addNoise = True,
+                                  cellsNameSuffix = 'WithNoise'))
 
-    # ecal barrel cells with noise filtered
-    ecalBarrelCellsNoiseFilteredLinks = ecalBarrelPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoiseFiltered",
-                                                                   doCellCalibration=True,
-                                                                   calibTool=calibEcalBarrel,
-                                                                   positionsTool=cellPositionEcalBarrelTool,
-                                                                   addCrosstalk=addCrosstalk,
-                                                                   crosstalkTool=readCrosstalkMap,
-                                                                   addCellNoise=True,
-                                                                   filterCellNoise=True,
-                                                                   noiseTool=ecalBarrelNoiseTool,
-                                                                   geometryTool=ecalBarrelGeometryTool,
-                                                                   OutputLevel=INFO,
-                                                                   hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
-                                                                   cells=ecalBarrelPositionedCellsName + "WithNoiseFiltered",
-                                                                   links=ecalBarrelCellsNoiseFilteredLinks
-                                                                   )
-    TopAlg += [createEcalBarrelCellsNoiseFiltered]
+    # cells with noise filtered
+    caldigi_cfg.merge(
+        CreateECalBarrelCellsCfg (flags,
+                                  'CreatePositionedECalBarrelCellsWithNoiseFiltered',
+                                  addNoise = True,
+                                  filterCellNoise = True,
+                                  cellsNameSuffix = 'WithNoiseFiltered'))
 
     # ecal endcap cells with noise not filtered
-    ecalEndcapCellsNoiseLinks = ecalEndcapPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
-    createEcalEndcapCellsNoise = CreatePositionedCaloCells("CreatePositionedECalEndcapCellsWithNoise",
-                                                           doCellCalibration=True,
-                                                           calibTool=calibEcalEndcap,
-                                                           positionsTool=cellPositionEcalEndcapTool,
-                                                           addCrosstalk=False,
-                                                           crosstalkTool=None,
-                                                           addCellNoise=True,
-                                                           filterCellNoise=False,
-                                                           noiseTool=ecalEndcapNoiseTool,
-                                                           geometryTool=ecalEndcapGeometryTool,
-                                                           OutputLevel=INFO,
-                                                           hits=ecalEndcapReadoutName,
-                                                           cells=ecalEndcapPositionedCellsName + "WithNoise",
-                                                           links=ecalEndcapCellsNoiseLinks)
-    TopAlg += [createEcalEndcapCellsNoise]
+    caldigi_cfg.merge(
+        CreateECalEndcapCellsCfg (flags,
+                                  'CreatePositionedECalEndcapCellsWithNoise',
+                                  addNoise = True,
+                                  cellsNameSuffix = 'WithNoise'))
 
     # ecal endcap cells with noise filtered
-    ecalEndcapCellsNoiseFilteredLinks = ecalEndcapPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
-    createEcalEndcapCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalEndcapCellsWithNoiseFiltered",
-                                                                   doCellCalibration=True,
-                                                                   calibTool=calibEcalEndcap,
-                                                                   positionsTool=cellPositionEcalEndcapTool,
-                                                                   addCrosstalk=False,
-                                                                   crosstalkTool=None,
-                                                                   addCellNoise=True,
-                                                                   filterCellNoise=True,
-                                                                   noiseTool=ecalEndcapNoiseTool,
-                                                                   geometryTool=ecalEndcapGeometryTool,
-                                                                   OutputLevel=INFO,
-                                                                   hits=ecalEndcapReadoutName,  # uncalibrated & unpositioned cells without noise
-                                                                   cells=ecalEndcapPositionedCellsName + "WithNoiseFiltered",
-                                                                   links=ecalEndcapCellsNoiseFilteredLinks
-                                                                   )
-    TopAlg += [createEcalEndcapCellsNoiseFiltered]
+    caldigi_cfg.merge(
+        CreateECalEndcapCellsCfg (flags,
+                                  'CreatePositionedECalEndcapCellsWithNoiseFiltered',
+                                  addNoise = True,
+                                  filterCellNoise = True,
+                                  cellsNameSuffix = 'WithNoiseFiltered'))
 
 if runHCal:
-    # Apply calibration and positioning to cells in HCal barrel
-    hcalBarrelPositionedCellsName = hcalBarrelReadoutName + "Positioned"
-    hcalBarrelLinks = hcalBarrelPositionedCellsName + "SimCaloHitLinks"
-    createHCalBarrelCells = CreatePositionedCaloCells("CreatePositionedHCalBarrelCells",
-                                                      doCellCalibration=True,
-                                                      calibTool=calibHCalBarrel,
-                                                      positionsTool=cellPositionHCalBarrelTool,
-                                                      addCellNoise=False,
-                                                      filterCellNoise=False,
-                                                      hits=hcalBarrelReadoutName,
-                                                      cells=hcalBarrelPositionedCellsName,
-                                                      links=hcalBarrelLinks,
-                                                      OutputLevel=INFO)
-    TopAlg += [createHCalBarrelCells]
+    from FCC_config.ALLEGRO.CreateCaloCellsConfig import \
+         CreateHCalBarrelCellsCfg, CreateHCalEndcapCellsCfg
+    caldigi_cfg.merge(CreateHCalBarrelCellsCfg(flags))
+    caldigi_cfg.merge(CreateHCalEndcapCellsCfg(flags))
 
-    # Apply calibration and positioning to cells in HCal endcap
-    hcalEndcapPositionedCellsName = hcalEndcapReadoutName + "Positioned"
-    hcalEndcapLinks = hcalEndcapPositionedCellsName + "SimCaloHitLinks"
-    createHCalEndcapCells = CreatePositionedCaloCells("CreatePositionedHCalEndcapCells",
-                                                      doCellCalibration=True,
-                                                      calibTool=calibHCalEndcap,
-                                                      addCellNoise=False,
-                                                      filterCellNoise=False,
-                                                      positionsTool=cellPositionHCalEndcapTool,
-                                                      OutputLevel=INFO,
-                                                      hits=hcalEndcapReadoutName,
-                                                      cells=hcalEndcapPositionedCellsName,
-                                                      links=hcalEndcapLinks)
-    TopAlg += [createHCalEndcapCells]
+caldigi_cfg.toVars (TopAlg, ExtSvc)
 
 
 # Muon cells [add longitudinal segmentation to detector?]
@@ -895,6 +582,7 @@ if runMuon:
         OutputLevel=INFO
     )
 
+    from Configurables import CreatePositionedCaloCells
     from Configurables import NoiseCaloCellsFlatTool
     MuonBarrelNoiseTool = NoiseCaloCellsFlatTool("MuonBarrelNoiseTool",
                                                  cellNoiseRMS=0.0005,  # in GeV
@@ -1009,7 +697,7 @@ def setupSWClusters(inputCells,
     caloIDs = []
     for (k, v) in inputCells.items():
         cells.append(v)
-        caloIDs.append(IDs[k])
+        caloIDs.append(detIDs(flags, k))
     # DEBUG
     print("Input cells")
     print(cells)
@@ -1050,7 +738,7 @@ def setupSWClusters(inputCells,
         correctClusterAlg = CorrectCaloClusters("Correct" + outputClusters,
                                                 inClusters=clusterAlg.clusters.Path,
                                                 outClusters="Corrected" + clusterAlg.clusters.Path,
-                                                systemIDs=[IDs["ECAL_Barrel"]],
+                                                systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                 numLayers=[ecalBarrelLayers],
                                                 firstLayerIDs=[0],
                                                 lastLayerIDs=[ecalBarrelLayers - 1],
@@ -1070,7 +758,7 @@ def setupSWClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel"]),
                                                          systemNames=["EMB"],
                                                          numLayers=[ecalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"]],
@@ -1085,7 +773,7 @@ def setupSWClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Endcap"]],
+                                                         systemIDs=detIDs(flags,["ECAL_Endcap"]),
                                                          systemNames=["EMEC"],
                                                          numLayers=[ecalEndcapLayers],
                                                          readoutNames=[inputReadouts["ECAL_Endcap"]],
@@ -1108,7 +796,7 @@ def setupSWClusters(inputCells,
                                                          #thetaFieldNames=["theta"]*4,  # will be ignored for systems!=EMB
                                                          #moduleFieldNames=["module"]*4,  # will be ignored for systems!=EMB
                                                          #thetaRecalcWeights=[ecalBarrelThetaWeights, [-1]*ecalEndcapLayers, [-1]*hcalBarrelLayers, [-1]*hcalEndcapLayers],
-                                                         systemIDs=[IDs["ECAL_Barrel"],IDs["HCAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel","HCAL_Barrel"]),
                                                          systemNames=["EMB", "HCALB"],
                                                          numLayers=[ecalBarrelLayers, hcalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"], inputReadouts["HCAL_Barrel"]],
@@ -1139,7 +827,7 @@ def setupSWClusters(inputCells,
         calibrateClustersAlg = CalibrateCaloClusters("Calibrate" + outputClusters,
                                                      inClusters=inClusters,
                                                      outClusters="Calibrated" + clusterAlg.clusters.Path,
-                                                     systemIDs=[IDs["ECAL_Barrel"]],
+                                                     systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                      systemNames=["EMB"],
                                                      numLayers=[ecalBarrelLayers],
                                                      firstLayerIDs=[0],
@@ -1195,7 +883,7 @@ def setupTopoClusters(inputCells,
     caloIDs = []
     for (k, v) in inputCells.items():
         cells.append(v)
-        caloIDs.append(IDs[k])
+        caloIDs.append(detIDs(flags, k))
 
     # Clustering parameters
     seedSigma = 6
@@ -1236,7 +924,7 @@ def setupTopoClusters(inputCells,
         correctClusterAlg = CorrectCaloClusters("Correct" + outputClusters,
                                                 inClusters=clusterAlg.clusters.Path,
                                                 outClusters="Corrected" + clusterAlg.clusters.Path,
-                                                systemIDs=[IDs["ECAL_Barrel"]],
+                                                systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                 numLayers=[ecalBarrelLayers],
                                                 firstLayerIDs=[0],
                                                 lastLayerIDs=[ecalBarrelLayers - 1],
@@ -1256,7 +944,7 @@ def setupTopoClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel"]),
                                                          systemNames=["EMB"],
                                                          numLayers=[ecalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"]],
@@ -1271,7 +959,7 @@ def setupTopoClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Endcap"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Endcap"]),
                                                          systemNames=["EMEC"],
                                                          numLayers=[ecalEndcapLayers],
                                                          readoutNames=[inputReadouts["ECAL_Endcap"]],
@@ -1294,7 +982,7 @@ def setupTopoClusters(inputCells,
                                                          #thetaFieldNames=["theta"]*4,  # will be ignored for systems!=EMB
                                                          #moduleFieldNames=["module"]*4,  # will be ignored for systems!=EMB
                                                          #thetaRecalcWeights=[ecalBarrelThetaWeights, [-1]*ecalEndcapLayers, [-1]*hcalBarrelLayers, [-1]*hcalEndcapLayers],
-                                                         systemIDs=[IDs["ECAL_Barrel"],IDs["HCAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel","HCAL_Barrel"]),
                                                          systemNames=["EMB", "HCALB"],
                                                          numLayers=[ecalBarrelLayers, hcalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"], inputReadouts["HCAL_Barrel"]],
@@ -1342,7 +1030,7 @@ def setupTopoClusters(inputCells,
         calibrateClustersAlg = CalibrateCaloClusters("Calibrate" + outputClusters,
                                                      inClusters=inClusters,
                                                      outClusters="Calibrated" + clusterAlg.clusters.Path,
-                                                     systemIDs=[IDs["ECAL_Barrel"]],
+                                                     systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                      systemNames=["EMB"],
                                                      numLayers=[ecalBarrelLayers],
                                                      firstLayerIDs=[0],
@@ -1376,8 +1064,8 @@ def setupTopoClusters(inputCells,
 
 if doSWClustering:
     # SW ECAL barrel clusters
-    EMBCaloClusterInputs = {"ECAL_Barrel": ecalBarrelPositionedCellsName}
-    EMBCaloClusterReadouts = {"ECAL_Barrel": ecalBarrelReadoutName}
+    EMBCaloClusterInputs = {"ECAL_Barrel": flags.ECal.Barrel.cellsName}
+    EMBCaloClusterReadouts = {"ECAL_Barrel": flags.ECal.Barrel.readoutName}
     setupSWClusters(EMBCaloClusterInputs,
                     EMBCaloClusterReadouts,
                     "EMBCaloClusters",
@@ -1388,8 +1076,8 @@ if doSWClustering:
                     runPhotonIDTool)
 
     # SW ECAL endcap clusters
-    EMECCaloClusterInputs = {"ECAL_Endcap": ecalEndcapPositionedCellsName}
-    EMECCaloClusterReadouts = {"ECAL_Endcap": ecalEndcapReadoutName}
+    EMECCaloClusterInputs = {"ECAL_Endcap": flags.ECal.Endcap.cellsName}
+    EMECCaloClusterReadouts = {"ECAL_Endcap": flags.ECal.Endcap.readoutName}
     setupSWClusters(EMECCaloClusterInputs,
                     EMECCaloClusterReadouts,
                     "EMECCaloClusters",
@@ -1401,7 +1089,7 @@ if doSWClustering:
 
     # SW ECAL barrel and endcap clusters with noise
     if addNoise:
-        EMBCaloClusterInputsWithNoise = {"ECAL_Barrel": ecalBarrelPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalBarrelPositionedCellsName + "WithNoiseFiltered"}
+        EMBCaloClusterInputsWithNoise = {"ECAL_Barrel": flags.ECal.Barrel.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Barrel.cellsName + "WithNoiseFiltered"}
         setupSWClusters(EMBCaloClusterInputsWithNoise,
                         EMBCaloClusterReadouts,
                         "EMBCaloClustersWithNoise" if filterNoiseThreshold < 0 else "EMBCaloClustersWithNoiseFiltered",
@@ -1411,7 +1099,7 @@ if doSWClustering:
                         addShapeParameters,
                         runPhotonIDTool)
 
-        EMECCaloClusterInputsWithNoise = {"ECAL_Endcap": ecalEndcapPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalEndcapPositionedCellsName + "WithNoiseFiltered"}
+        EMECCaloClusterInputsWithNoise = {"ECAL_Endcap": flags.ECal.Endcap.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Endcap.cellsName + "WithNoiseFiltered"}
         setupSWClusters(EMECCaloClusterInputsWithNoise,
                         EMECCaloClusterReadouts,
                         "EMECCaloClustersWithNoise" if filterNoiseThreshold < 0 else "EMECCaloClustersWithNoiseFiltered",
@@ -1424,16 +1112,16 @@ if doSWClustering:
     # ECAL + HCAL clusters
     if runHCal:
         CaloClusterInputs = {
-            "ECAL_Barrel": ecalBarrelPositionedCellsName,
-            "ECAL_Endcap": ecalEndcapPositionedCellsName,
-            "HCAL_Barrel": hcalBarrelPositionedCellsName,
-            "HCAL_Endcap": hcalEndcapPositionedCellsName,
+            "ECAL_Barrel": flags.ECal.Barrel.cellsName,
+            "ECAL_Endcap": flags.ECal.Endcap.cellsName,
+            "HCAL_Barrel": flags.HCal.Barrel.cellsName,
+            "HCAL_Endcap": flags.HCal.Endcap.cellsName,
         }
         CaloClusterReadouts = {
-            "ECAL_Barrel": ecalBarrelReadoutName,
-            "ECAL_Endcap": ecalEndcapReadoutName,
-            "HCAL_Barrel": hcalBarrelReadoutName,
-            "HCAL_Endcap": hcalEndcapReadoutName,
+            "ECAL_Barrel": flags.ECal.Barrel.readoutName,
+            "ECAL_Endcap": flags.ECal.Endcap.readoutName,
+            "HCAL_Barrel": flags.HCal.Barrel.readoutName,
+            "HCAL_Endcap": flags.HCal.Endcap.readoutName,
         }
         setupSWClusters(CaloClusterInputs,
                         CaloClusterReadouts,
@@ -1466,8 +1154,8 @@ if doSWClustering:
 
 if doTopoClustering:
     # ECAL barrel topoclusters
-    EMBCaloTopoClusterInputs = {"ECAL_Barrel": ecalBarrelPositionedCellsName}
-    EMBCaloTopoClusterReadouts = {"ECAL_Barrel": ecalBarrelReadoutName}
+    EMBCaloTopoClusterInputs = {"ECAL_Barrel": flags.ECal.Barrel.cellsName}
+    EMBCaloTopoClusterReadouts = {"ECAL_Barrel": flags.ECal.Barrel.readoutName}
     setupTopoClusters(EMBCaloTopoClusterInputs,
                       EMBCaloTopoClusterReadouts,
                       "EMBCaloTopoClusters",
@@ -1480,8 +1168,8 @@ if doTopoClustering:
                       runPhotonIDTool)
 
     # ECAL endcap topoclusters
-    EMECCaloTopoClusterInputs = {"ECAL_Endcap": ecalEndcapPositionedCellsName}
-    EMECCaloTopoClusterReadouts = {"ECAL_Endcap": ecalEndcapReadoutName}
+    EMECCaloTopoClusterInputs = {"ECAL_Endcap": flags.ECal.Endcap.cellsName}
+    EMECCaloTopoClusterReadouts = {"ECAL_Endcap": flags.ECal.Endcap.readoutName}
     setupTopoClusters(EMECCaloTopoClusterInputs,
                       EMECCaloTopoClusterReadouts,
                       "EMECCaloTopoClusters",
@@ -1495,7 +1183,7 @@ if doTopoClustering:
 
     # ECAL topoclusters with noise
     if addNoise:
-        EMBCaloTopoClusterInputsWithNoise = {"ECAL_Barrel": ecalBarrelPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalBarrelPositionedCellsName + "WithNoiseFiltered"}
+        EMBCaloTopoClusterInputsWithNoise = {"ECAL_Barrel": flags.ECal.Barrel.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Barrel.cellsName + "WithNoiseFiltered"}
         setupTopoClusters(EMBCaloTopoClusterInputsWithNoise,
                           EMBCaloTopoClusterReadouts,
                           "EMBCaloTopoClustersWithNoise" if filterNoiseThreshold < 0 else "EMBCaloTopoClustersWithNoiseFiltered",
@@ -1507,7 +1195,7 @@ if doTopoClustering:
                           addShapeParameters,
                           runPhotonIDTool)
 
-        EMECCaloTopoClusterInputsWithNoise = {"ECAL_Endcap": ecalEndcapPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalEndcapPositionedCellsName + "WithNoiseFiltered"}
+        EMECCaloTopoClusterInputsWithNoise = {"ECAL_Endcap": flags.ECal.Endcap.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Endcap.cellsName + "WithNoiseFiltered"}
         setupTopoClusters(EMECCaloTopoClusterInputsWithNoise,
                           EMECCaloTopoClusterReadouts,
                           "EMECCaloTopoClustersWithNoise" if filterNoiseThreshold < 0 else "EMECCaloTopoClustersWithNoiseFiltered",
@@ -1522,16 +1210,16 @@ if doTopoClustering:
     # ECAL + HCAL
     if runHCal:
         CaloTopoClusterInputs = {
-            "ECAL_Barrel": ecalBarrelPositionedCellsName,
-            "ECAL_Endcap": ecalEndcapPositionedCellsName,
-            "HCAL_Barrel": hcalBarrelPositionedCellsName,
-            "HCAL_Endcap": hcalEndcapPositionedCellsName,
+            "ECAL_Barrel": flags.ECal.Barrel.cellsName,
+            "ECAL_Endcap": flags.ECal.Endcap.cellsName,
+            "HCAL_Barrel": flags.HCal.Barrel.cellsName,
+            "HCAL_Endcap": flags.HCal.Endcap.cellsName,
         }
         CaloTopoClusterReadouts = {
-            "ECAL_Barrel": ecalBarrelReadoutName,
-            "ECAL_Endcap": ecalEndcapReadoutName,
-            "HCAL_Barrel": hcalBarrelReadoutName,
-            "HCAL_Endcap": hcalEndcapReadoutName,
+            "ECAL_Barrel": flags.ECal.Barrel.readoutName,
+            "ECAL_Endcap": flags.ECal.Endcap.readoutName,
+            "HCAL_Barrel": flags.HCal.Barrel.readoutName,
+            "HCAL_Endcap": flags.HCal.Endcap.readoutName,
         }
         # note: the neighbour map links ecal and hcal barrels, and hcal barrel-endcap, but does not link (yet) the others
         setupTopoClusters(CaloTopoClusterInputs,
@@ -1549,9 +1237,9 @@ if doTopoClustering:
 # Create CaloHit<->MCParticle links (needed for training datasets for MLPF)
 # Also store Cluster<->MCParticle links (for truth matching for efficiency and purity studies)
 from Configurables import CreateTruthLinks
-caloLinks = [ecalBarrelLinks, ecalEndcapLinks]
+caloLinks = [flags.ECal.Barrel.linksName, flags.ECal.Endcap.linksName]
 if runHCal:
-    caloLinks += [hcalBarrelLinks, hcalEndcapLinks]
+    caloLinks += [flags.HCal.Barrel.linksName, flags.HCal.Endcap.linksName]
 if runMuon:
     caloLinks += [muonBarrelLinks, muonEndcapLinks]
 createTruthLinks = CreateTruthLinks("CreateTruthLinks",
@@ -1572,12 +1260,12 @@ io_svc.outputCommands = ["keep *",
 
 # drop the uncalibrated cells
 if dropUncalibratedCells:
-    io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Barrel.readoutName)
     io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName2)
-    io_svc.outputCommands.append("drop %s" % ecalEndcapReadoutName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Endcap.readoutName)
     if runHCal:
-        io_svc.outputCommands.append("drop %s" % hcalBarrelReadoutName)
-        io_svc.outputCommands.append("drop %s" % hcalEndcapReadoutName)
+        io_svc.outputCommands.append("drop %s" % flags.HCal.Barrel.readoutName)
+        io_svc.outputCommands.append("drop %s" % flags.HCal.Endcap.readoutName)
     else:
         io_svc.outputCommands += ["drop HCal*"]
 
@@ -1603,18 +1291,18 @@ if dropMuonHits:
 
 # drop hits/positioned cells/cluster cells if desired
 if not saveHits:
-    io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop *%sContributions" % flags.ECal.Barrel.readoutName)
     io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName2)
-    io_svc.outputCommands.append("drop *%sContributions" % ecalEndcapReadoutName)
+    io_svc.outputCommands.append("drop *%sContributions" % flags.ECal.Endcap.readoutName)
     if runHCal:
-        io_svc.outputCommands.append("drop *%sContributions" % hcalBarrelReadoutName)
-        io_svc.outputCommands.append("drop *%sContributions" % hcalEndcapReadoutName)
+        io_svc.outputCommands.append("drop *%sContributions" % flags.HCal.Barrel.readoutName)
+        io_svc.outputCommands.append("drop *%sContributions" % flags.HCal.Endcap.readoutName)
 if not saveCells:
-    io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName)
-    io_svc.outputCommands.append("drop %s" % ecalEndcapPositionedCellsName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Barrel.cellsName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Endcap.cellsName)
     if addNoise:
-        io_svc.outputCommands.append("drop %sWithNoise*" % ecalBarrelPositionedCellsName)
-        io_svc.outputCommands.append("drop %sWithNoise*" % ecalEndcapPositionedCellsName)
+        io_svc.outputCommands.append("drop %sWithNoise*" % flags.ECal.Barrel.cellsName)
+        io_svc.outputCommands.append("drop %sWithNoise*" % flags.ECal.Endcap.cellsName)
     if resegmentECalBarrel:
         io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName2)
     if runHCal:

--- a/FCCee/FullSim/ALLEGRO/ALLEGRO_o2_v01/run_digi_reco.py
+++ b/FCCee/FullSim/ALLEGRO/ALLEGRO_o2_v01/run_digi_reco.py
@@ -97,40 +97,13 @@ dropMuonHits = False
 # ECAL barrel parameters for digitization
 # TODO: extract number of layers (for ECAL and HCAL) directly from the detector segmentations
 ecalBarrelLayers = 11
-# e-, 10 GeV, flat theta, B field off
-# ecalBarrelSamplingFraction = [0.3800493723322256] * 1 + [0.13494147915064658] * 1 + [0.142866851721152] * 1 + [0.14839315921940666] * 1 + [0.15298362570665006] * 1 + [0.15709704561942747] * 1 + [0.16063717490147533] * 1 + [0.1641723795419055] * 1 + [0.16845490287689746] * 1 + [0.17111520115997653] * 1 + [0.1730605163148862] * 1
-# e-, 20 GeV, flat theta, B field on
-# LAr+Pb
-ecalBarrelSamplingFraction = [0.3790943904011486] * 1 + [0.1355600584387894] * 1 + [0.14628210607758893] * 1 + [0.15274136994224854] * 1 + [0.15817255837886351] * 1 + [0.16290355087527258] * 1 + [0.1674201708055751] * 1 + [0.1715846423182708] * 1 + [0.17558662106635545] * 1 + [0.18002243792463576] * 1 + [0.18288329976007917] * 1
-# LKr+W
-# ecalBarrelSamplingFraction = [0.4806159038189229, 0.2822724529941907, 0.29324811578621524, 0.2996356722403102, 0.3047116566166906, 0.3090324459212472, 0.3133282052725273, 0.3173868504112048, 0.3215311396527887, 0.32516920330802673, 0.3318488881234955]
-
 ecalBarrelUpstreamParameters = [[0.028158491043365624, -1.564259408365951, -76.52312805346982, 0.7442903558010191, -34.894692961350195, -74.19340877431723]]
 ecalBarrelDownstreamParameters = [[0.00010587711361028165, 0.0052371999097777355, 0.69906696456064, -0.9348243433360095, -0.0364714212117143, 8.360401126995626]]
-if ecalBarrelSamplingFraction and len(ecalBarrelSamplingFraction) > 0:
-    assert (ecalBarrelLayers == len(ecalBarrelSamplingFraction))
 # ECAL endcap parameters for digitization
-# the turbine endcap has calibration "layers" in the both the z and radial
-# directions, for each of the three wheels.  So the total number of layers
-# is given by:
-#
-#   ECalEndcapNumCalibZLayersWheel1*ECalEndcapNumCalibRhoLayersWheel1
-#  +ECalEndcapNumCalibZLayersWheel2*ECalEndcapNumCalibRhoLayersWheel2
-#  +ECalEndcapNumCalibZLayersWheel3*ECalEndcapNumCalibRhoLayersWheel3
-#
-# which in the current design is 5*10+1*14+1*34 = 98
-# NB some cells near the inner and outer edges of the calorimeter are difficult
-# to calibrate as they are not part of the core of well-contained showers.
-# The calibrated values can be <0 or >1 for such cells, so these nonsenical
-# numbers are replaced by 1
 ecalEndcapLayers = 98
-ecalEndcapSamplingFraction = [0.0897818] * 1+ [0.221318] * 1+ [0.0820002] * 1+ [0.994281] * 1+ [0.0414437] * 1+ [0.1148] * 1+ [0.178831] * 1+ [0.142449] * 1+ [0.181206] * 1+ [0.342843] * 1+ [0.137479] * 1+ [0.176479] * 1+ [0.153273] * 1+ [0.195836] * 1+ [0.0780405] * 1+ [0.150202] * 1+ [0.17846] * 1+ [0.164886] * 1+ [0.175758] * 1+ [0.10836] * 1+ [0.160243] * 1+ [0.183373] * 1+ [0.171818] * 1+ [0.194848] * 1+ [0.111899] * 1+ [0.170704] * 1+ [0.188455] * 1+ [0.178164] * 1+ [0.209113] * 1+ [0.105241] * 1+ [0.180637] * 1+ [0.192206] * 1+ [0.186096] * 1+ [0.211962] * 1+ [0.112019] * 1+ [0.180344] * 1+ [0.195684] * 1+ [0.190778] * 1+ [0.218259] * 1+ [0.118516] * 1+ [0.207786] * 1+ [0.204474] * 1+ [0.207048] * 1+ [0.225913] * 1+ [0.111325] * 1+ [0.147875] * 1+ [0.195625] * 1+ [0.173326] * 1+ [0.175449] * 1+ [0.104087] * 1+ [0.153645] * 1+ [0.161263] * 1+ [0.165499] * 1+ [0.171758] * 1+ [0.175789] * 1+ [0.180657] * 1+ [0.184563] * 1+ [0.187876] * 1+ [0.191762] * 1+ [0.19426] * 1+ [0.197959] * 1+ [0.199021] * 1+ [0.204428] * 1+ [0.195709] * 1+ [0.151751] * 1+ [0.171477] * 1+ [0.165509] * 1+ [0.172565] * 1+ [0.172961] * 1+ [0.175534] * 1+ [0.177989] * 1+ [0.18026] * 1+ [0.181898] * 1+ [0.183912] * 1+ [0.185654] * 1+ [0.187515] * 1+ [0.190408] * 1+ [0.188794] * 1+ [0.193699] * 1+ [0.192287] * 1+ [0.19755] * 1+ [0.190943] * 1+ [0.218553] * 1+ [0.161085] * 1+ [0.373086] * 1+ [0.122495] * 1+ [0.21103] * 1+ [1] * 1+ [0.138686] * 1+ [0.0545171] * 1+ [1] * 1+ [1] * 1+ [0.227945] * 1+ [0.0122872] * 1+ [0.00437334] * 1+ [0.00363533] * 1+ [1] * 1+ [1] * 1
-if ecalEndcapSamplingFraction and len(ecalEndcapSamplingFraction) > 0:
-    assert (ecalEndcapLayers == len(ecalEndcapSamplingFraction))
 
 resegmentECalBarrel = False
 
-ecalEndcapWheels = 3
 hcalBarrelLayers = 13
 hcalEndcapLayers = 22
 
@@ -172,6 +145,7 @@ addPi0RecoTool = opts.reconstructPi0s
 #
 TopAlg = []  # alg sequence
 ExtSvc = []  # list of external services
+from FCC_config.ComponentAccumulator import ComponentAccumulator
 
 
 # Event counter
@@ -210,30 +184,19 @@ geoservice.detectors = [
 ]
 ExtSvc += [geoservice]
 
-# retrieve subdetector IDs
-import xml.etree.ElementTree as ET
-tree = ET.parse(path_to_detector + 'DectDimensions.xml')
-root = tree.getroot()
-IDs = {}
-for constant in root.find('define').findall('constant'):
-    if (
-        constant.get('name') == 'DetID_VXD_Barrel'
-        or constant.get('name') == 'DetID_VXD_Disks'
-        or constant.get('name') == 'DetID_STT'
-        or constant.get('name') == 'DetID_SiWr_Barrel'
-        or constant.get('name') == 'DetID_SiWr_Disks'
-        or constant.get('name') == 'DetID_ECAL_Barrel'
-        or constant.get('name') == 'DetID_ECAL_Endcap'
-        or constant.get('name') == 'DetID_HCAL_Barrel'
-        or constant.get('name') == 'DetID_HCAL_Endcap'
-        or constant.get('name') == 'DetID_Muon_Barrel'
-    ):
-        IDs[constant.get("name")[6:]] = int(constant.get('value'))
-    if (constant.get('name') == 'DetID_Muon_Endcap_1'):
-        IDs[constant.get("name")[6:-2]] = int(constant.get('value'))
-# debug
-print("Subdetector IDs:")
-print(IDs)
+from FCC_config.DetIDs import detIDs
+
+
+# Configuration flags.
+class Flags:
+    pass
+flags = Flags()
+flags.compactFile = geoservice.detectors[0]
+flags.dataFiles = dataFolder
+from FCC_config.ALLEGRO.CreateCaloCellsConfig import defineCaloCellFlags
+defineCaloCellFlags(flags)
+flags.ECal.Barrel.addCrosstalk = addCrosstalk
+
 
 # Input/Output handling
 from k4FWCore import IOSvc
@@ -262,11 +225,12 @@ if addTracks:
                                                     OutputMCRecoTrackParticleAssociation=["TracksFromGenParticlesAssociation"],
                                                     ExtrapolateToECal=True,
                                                     KeepOnlyBestExtrapolation=False,
-                                                    TrackerIDs=[IDs["VXD_Barrel"],
-                                                                IDs["VXD_Disks"],
-                                                                IDs["STT"],
-                                                                IDs["SiWr_Barrel"],
-                                                                IDs["SiWr_Disks"]],
+                                                    TrackerIDs=detIDs(flags,
+                                                                      ["VXD_Barrel",
+                                                                       "VXD_Disks",
+                                                                       "STT",
+                                                                       "SiWr_Barrel",
+                                                                       "SiWr_Disks"]),
                                                     OutputLevel=INFO)
     TopAlg += [tracksFromGenParticles]
 
@@ -524,364 +488,86 @@ if runTrkFitter:
 
 # Calorimeter digitization (merging hits into cells, EM scale calibration via sampling fractions)
 
+caldigi_cfg = ComponentAccumulator()
+
 # - ECAL readouts
-ecalBarrelReadoutName = "ECalBarrelModuleThetaMerged"      # barrel, original segmentation (baseline)
 ecalBarrelReadoutName2 = "ECalBarrelModuleThetaMerged2"    # barrel, after re-segmentation (for optimisation studies)
-ecalEndcapReadoutName = "ECalEndcapTurbine"                # endcap, turbine-like (baseline)
-# - HCAL readouts
-if runHCal:
-    hcalBarrelReadoutName = "HCalBarrelReadout"            # barrel, original segmentation (phi-theta)
-    # hcalBarrelReadoutName = "HCalBarrelReadoutPhiRow"    # barrel, alternative segmentation (phi-row)
-    hcalEndcapReadoutName = "HCalEndcapReadout"            # endcap, original segmentation
-else:
-    hcalBarrelReadoutName = ""
-    hcalEndcapReadoutName = ""
-
-# - Configure geometry tools and indexing service.
-geotools = []
-from Configurables import TubeLayerModuleThetaCaloTool
-ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
-                                                      readoutName=ecalBarrelReadoutName,
-                                                      activeVolumeName="LAr_sensitive",
-                                                      activeFieldName="layer",
-                                                      activeVolumesNumber=ecalBarrelLayers,
-                                                      fieldNames=["system"],
-                                                      fieldValues=[IDs["ECAL_Barrel"]],
-                                                      OutputLevel=INFO)
-geotools += [ecalBarrelGeometryTool]
-
-from Configurables import TurbineEndcapCaloTool
-ecalEndcapGeometryTool = TurbineEndcapCaloTool ("ecalEndcapGeometryTool",
-                                                readoutName=ecalEndcapReadoutName)
-geotools += [ecalEndcapGeometryTool]
-
-if runHCal:
-    from Configurables import HCalPhiThetaCaloTool
-    hcalBarrelGeometryTool = HCalPhiThetaCaloTool ("hcalBarrelGeometryTool",
-                                                   readoutName=hcalBarrelReadoutName)
-    geotools += [hcalBarrelGeometryTool]
-    hcalEndcapGeometryTool = HCalPhiThetaCaloTool ("hcalEndcapGeometryTool",
-                                                   readoutName=hcalEndcapReadoutName)
-    geotools += [hcalEndcapGeometryTool]
-    
-
-from Configurables import k4__recCalo__CaloCellIndexerSvc
-ExtSvc += [k4__recCalo__CaloCellIndexerSvc (GeoTools = geotools)]
-
-
-# - EM scale calibration (sampling fraction)
-from Configurables import CalibrateInLayersTool
-#   * ECAL barrel
-calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
-                                        samplingFraction=ecalBarrelSamplingFraction,
-                                        readoutName=ecalBarrelReadoutName,
-                                        layerFieldName="layer")
-#   * ECAL endcap
-calibEcalEndcap = CalibrateInLayersTool("CalibrateECalEndcap",
-                                        samplingFraction=ecalEndcapSamplingFraction,
-                                        readoutName=ecalEndcapReadoutName,
-                                        layerFieldName="layer")
-
-if runHCal:
-    from Configurables import CalibrateCaloHitsTool
-    # HCAL barrel
-    calibHCalBarrel = CalibrateCaloHitsTool(
-        "CalibrateHCalBarrel", invSamplingFraction="29.4202")
-    # HCAL endcap
-    calibHCalEndcap = CalibrateCaloHitsTool(
-        "CalibrateHCalEndcap", invSamplingFraction="29.4202")  # FIXME: to be updated for ddsim
-
-# - cell positioning tools
-from Configurables import CellPositionsECalBarrelModuleThetaSegTool
-cellPositionEcalBarrelTool = CellPositionsECalBarrelModuleThetaSegTool(
-    "CellPositionsECalBarrel",
-    readoutName=ecalBarrelReadoutName,
-    OutputLevel=INFO
-)
-# the noise tool needs the positioning tool, but if I reuse the previous one the code crashes..
-cellPositionEcalBarrelToolForNoise = CellPositionsECalBarrelModuleThetaSegTool(
-    "CellPositionsECalBarrelForNoise",
-    readoutName=ecalBarrelReadoutName,
-    OutputLevel=INFO
-)
-if resegmentECalBarrel:
-    cellPositionEcalBarrelTool2 = CellPositionsECalBarrelModuleThetaSegTool(
-        "CellPositionsECalBarrel2",
-        readoutName=ecalBarrelReadoutName2,
-        OutputLevel=INFO
-    )
-
-from Configurables import CellPositionsECalEndcapTurbineSegTool
-cellPositionEcalEndcapTool = CellPositionsECalEndcapTurbineSegTool(
-    "CellPositionsECalEndcap",
-    readoutName=ecalEndcapReadoutName,
-    OutputLevel=INFO
-)
-cellPositionEcalEndcapToolForNoise = CellPositionsECalEndcapTurbineSegTool(
-    "CellPositionsECalEndcapForNoise",
-    readoutName=ecalEndcapReadoutName,
-    OutputLevel=INFO
-)
-
-if runHCal:
-    from Configurables import CellPositionsHCalPhiThetaSegTool
-    cellPositionHCalBarrelTool = CellPositionsHCalPhiThetaSegTool(
-        "CellPositionsHCalBarrel",
-        readoutName=hcalBarrelReadoutName,
-        detectorName="HCalBarrel",
-        OutputLevel=INFO
-    )
-    cellPositionHCalEndcapTool = CellPositionsHCalPhiThetaSegTool(
-        "CellPositionsHCalEndcap",
-        readoutName=hcalEndcapReadoutName,
-        detectorName="HCalThreePartsEndcap",
-        numLayersHCalThreeParts=[6, 9, 22],
-        OutputLevel=INFO
-    )
-
-# - crosstalk tool
-if addCrosstalk:
-    from Configurables import ReadCaloCrosstalkMap
-    # read the crosstalk map
-    readCrosstalkMap = ReadCaloCrosstalkMap("ReadCrosstalkMap",
-                                            fileName=dataFolder+"xtalk_neighbours_map_ecalB_thetamodulemerged.root",
-                                            OutputLevel=INFO)
-else:
-    readCrosstalkMap = None
-
-# - noise tool
-if addNoise:
-    ecalBarrelNoisePath = dataFolder + "elecNoise_ecalBarrelFCCee_theta.root"
-    ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
-    from Configurables import NoiseCaloCellsFromFileBarrelTool
-    ecalBarrelNoiseTool = NoiseCaloCellsFromFileBarrelTool(
-        "ecalBarrelNoiseTool",
-        cellPositionsTool=cellPositionEcalBarrelToolForNoise,
-        readoutName=ecalBarrelReadoutName,
-        noiseFileName=ecalBarrelNoisePath,
-        elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
-        setNoiseOffset=False,
-        activeFieldName="layer",
-        addPileup=False,
-        filterNoiseThreshold=filterNoiseThreshold,
-        useAbsInFilter=True,
-        numHistograms=ecalBarrelLayers,
-        scaleFactor=1 / 1000.,  # MeV to GeV
-        OutputLevel=INFO
-    )
-
-
-    ecalEndcapNoisePath = dataFolder + "elecNoise_ecalendcap.root"
-    ecalEndcapNoiseRMSHistName = "noise_endcap_wheel"
-    from Configurables import NoiseCaloCellsFromFileTurbineEndcapTool
-    ecalEndcapNoiseTool = NoiseCaloCellsFromFileTurbineEndcapTool("ecalEndcapNoiseTool",
-                                                                  cellPositionsTool=cellPositionEcalEndcapToolForNoise,
-                                                                  readoutName=ecalEndcapReadoutName,
-                                                                  noiseFileName=ecalEndcapNoisePath,
-                                                                  elecNoiseRMSHistoName=ecalEndcapNoiseRMSHistName,
-                                                                  setNoiseOffset=False,
-                                                                  activeFieldName="wheel",
-                                                                  addPileup=False,
-                                                                  filterNoiseThreshold=filterNoiseThreshold,
-                                                                  useAbsInFilter=True,
-                                                                  numHistograms=ecalEndcapWheels,  # 3 wheels
-                                                                  scaleFactor=1 / 1000.,  # MeV to GeV
-                                                                  OutputLevel=INFO)
-
-else:
-    ecalBarrelNoiseTool = None
-    ecalBarrelGeometryTool = None
-    ecalEndcapNoiseTool = None
-    ecalEndcapGeometryTool = None
+ecalBarrelHitsMergedName = 'ECalBarrelCellsMerged'
+ecalBarrelPositionedCellsName2 = ecalBarrelReadoutName2 + "Positioned"
 
 # Create cells in ECal barrel (calibrated and positioned - optionally with xtalk and noise added)
 # from uncalibrated cells (+cellID info) from ddsim
-ecalBarrelPositionedCellsName = ecalBarrelReadoutName + "Positioned"
-ecalBarrelLinks = ecalBarrelPositionedCellsName + "SimCaloHitLinks"
-from Configurables import CreatePositionedCaloCells
-createEcalBarrelCells = CreatePositionedCaloCells("CreatePositionedECalBarrelCells",
-                                                  doCellCalibration=True,
-                                                  calibTool=calibEcalBarrel,
-                                                  positionsTool=cellPositionEcalBarrelTool,
-                                                  addCrosstalk=addCrosstalk,
-                                                  crosstalkTool=readCrosstalkMap,
-                                                  addCellNoise=False,
-                                                  filterCellNoise=False,
-                                                  noiseTool=None,
-                                                  geometryTool=ecalBarrelGeometryTool,
-                                                  OutputLevel=INFO,
-                                                  hits=ecalBarrelReadoutName,
-                                                  cells=ecalBarrelPositionedCellsName,
-                                                  links=ecalBarrelLinks
-                                                  )
-TopAlg += [createEcalBarrelCells]
+from FCC_config.ALLEGRO.CreateCaloCellsConfig import CreateECalBarrelCellsCfg
+caldigi_cfg.merge(CreateECalBarrelCellsCfg(flags))
 
 # -  now, if we want to also save cells with coarser granularity:
 if resegmentECalBarrel:
     # rewrite the cellId using the merged theta-module segmentation
-    # (merging several modules and severla theta readout cells).
+    # (merging several modules and several theta readout cells).
     # Add noise at this step if you derived the noise already assuming merged cells
     # Step a: compute new cellID of cells based on new readout
     # (merged module-theta segmentation with variable merging vs layer)
-    from Configurables import RedoSegmentation
-    resegmentEcalBarrelTool = RedoSegmentation("ReSegmentationEcal",
-                                               # old bitfield (readout)
-                                               oldReadoutName=ecalBarrelReadoutName,
-                                               # specify which fields are going to be altered (deleted/rewritten)
-                                               oldSegmentationIds=["module", "theta"],
-                                               # new bitfield (readout), with new segmentation (merged modules and theta cells)
-                                               newReadoutName=ecalBarrelReadoutName2,
-                                               OutputLevel=INFO,
-                                               debugPrint=200,
-                                               inhits=ecalBarrelPositionedCellsName,
-                                               outhits="ECalBarrelCellsMerged")
+    from FCC_config.ALLEGRO.CreateCaloCellsConfig import ReSegmentationECalBarrelCfg
+    caldigi_cfg.merge (
+        ReSegmentationECalBarrelCfg(flags,
+                                    newReadoutName = ecalBarrelReadoutName2,
+                                    newCellsName = ecalBarrelHitsMergedName))
 
     # Step b: merge new cells with same cellID together
     # do not apply cell calibration again since cells were already
     # calibrated in Step 1
     # noise and xtalk off assuming they were applied earlier
-    ecalBarrelPositionedCellsName2 = ecalBarrelReadoutName2 + "Positioned"
-    ecalBarrelLinks2 = ecalBarrelPositionedCellsName2 + "SimCaloHitLinks"
-    createEcalBarrelCells2 = CreatePositionedCaloCells("CreatePositionedECalBarrelCells2",
-                                                       doCellCalibration=False,
-                                                       positionsTool=cellPositionEcalBarrelTool2,
-                                                       calibTool=None,
-                                                       crosstalkTool=None,
-                                                       addCrosstalk=False,
-                                                       addCellNoise=False,
-                                                       filterCellNoise=False,
-                                                       OutputLevel=INFO,
-                                                       hits="ECalBarrelCellsMerged",
-                                                       cells=ecalBarrelPositionedCellsName2,
-                                                       links=ecalBarrelLinks2)
-    TopAlg += [
-        resegmentEcalBarrelTool,
-        createEcalBarrelCells2,
-    ]
+    caldigi_cfg.merge (
+        CreateECalBarrelCellsCfg(flags,
+                                 'CreatePositionedECalBarrelCells2',
+                                 hits = ecalBarrelHitsMergedName,
+                                 readoutName=ecalBarrelReadoutName2,
+                                 addCrosstalk = False,
+                                 doCellCalibration = False))
 
 # Create cells in ECal endcap (needed if one wants to apply cell calibration,
 # which is not performed by ddsim)
-ecalEndcapPositionedCellsName = ecalEndcapReadoutName + "Positioned"
-ecalEndcapLinks = ecalEndcapPositionedCellsName + "SimCaloHitLinks"
-createEcalEndcapCells = CreatePositionedCaloCells("CreatePositionedECalEndcapCells",
-                                                  doCellCalibration=True,
-                                                  positionsTool=cellPositionEcalEndcapTool,
-                                                  calibTool=calibEcalEndcap,
-                                                  crosstalkTool=None,
-                                                  addCrosstalk=False,
-                                                  addCellNoise=False,
-                                                  filterCellNoise=False,
-                                                  OutputLevel=INFO,
-                                                  hits=ecalEndcapReadoutName,
-                                                  cells=ecalEndcapPositionedCellsName,
-                                                  links=ecalEndcapLinks)
-TopAlg += [createEcalEndcapCells]
+from FCC_config.ALLEGRO.CreateCaloCellsConfig import CreateECalEndcapCellsCfg
+caldigi_cfg.merge(CreateECalEndcapCellsCfg(flags))
 
 if addNoise:
-    # ecal barrel cells with noise not filtered
-    ecalBarrelCellsNoiseLinks = ecalBarrelPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoise = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoise",
-                                                           doCellCalibration=True,
-                                                           calibTool=calibEcalBarrel,
-                                                           positionsTool=cellPositionEcalBarrelTool,
-                                                           addCrosstalk=addCrosstalk,
-                                                           crosstalkTool=readCrosstalkMap,
-                                                           addCellNoise=True,
-                                                           filterCellNoise=False,
-                                                           noiseTool=ecalBarrelNoiseTool,
-                                                           geometryTool=ecalBarrelGeometryTool,
-                                                           OutputLevel=INFO,
-                                                           hits=ecalBarrelReadoutName,
-                                                           cells=ecalBarrelPositionedCellsName + "WithNoise",
-                                                           links=ecalBarrelCellsNoiseLinks)
-    TopAlg += [createEcalBarrelCellsNoise]
+    # cells with noise not filtered
+    caldigi_cfg.merge(
+        CreateECalBarrelCellsCfg (flags,
+                                  'CreatePositionedECalBarrelCellsWithNoise',
+                                  addNoise = True,
+                                  cellsNameSuffix = 'WithNoise'))
 
-    # ecal barrel cells with noise filtered
-    ecalBarrelCellsNoiseFilteredLinks = ecalBarrelPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoiseFiltered",
-                                                                   doCellCalibration=True,
-                                                                   calibTool=calibEcalBarrel,
-                                                                   positionsTool=cellPositionEcalBarrelTool,
-                                                                   addCrosstalk=addCrosstalk,
-                                                                   crosstalkTool=readCrosstalkMap,
-                                                                   addCellNoise=True,
-                                                                   filterCellNoise=True,
-                                                                   noiseTool=ecalBarrelNoiseTool,
-                                                                   geometryTool=ecalBarrelGeometryTool,
-                                                                   OutputLevel=INFO,
-                                                                   hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
-                                                                   cells=ecalBarrelPositionedCellsName + "WithNoiseFiltered",
-                                                                   links=ecalBarrelCellsNoiseFilteredLinks
-                                                                   )
-    TopAlg += [createEcalBarrelCellsNoiseFiltered]
+    # cells with noise filtered
+    caldigi_cfg.merge(
+        CreateECalBarrelCellsCfg (flags,
+                                  'CreatePositionedECalBarrelCellsWithNoiseFiltered',
+                                  addNoise = True,
+                                  filterCellNoise = True,
+                                  cellsNameSuffix = 'WithNoiseFiltered'))
 
     # ecal endcap cells with noise not filtered
-    ecalEndcapCellsNoiseLinks = ecalEndcapPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
-    createEcalEndcapCellsNoise = CreatePositionedCaloCells("CreatePositionedECalEndcapCellsWithNoise",
-                                                           doCellCalibration=True,
-                                                           calibTool=calibEcalEndcap,
-                                                           positionsTool=cellPositionEcalEndcapTool,
-                                                           addCrosstalk=False,
-                                                           crosstalkTool=None,
-                                                           addCellNoise=True,
-                                                           filterCellNoise=False,
-                                                           noiseTool=ecalEndcapNoiseTool,
-                                                           geometryTool=ecalEndcapGeometryTool,
-                                                           OutputLevel=INFO,
-                                                           hits=ecalEndcapReadoutName,
-                                                           cells=ecalEndcapPositionedCellsName + "WithNoise",
-                                                           links=ecalEndcapCellsNoiseLinks)
-    TopAlg += [createEcalEndcapCellsNoise]
+    caldigi_cfg.merge(
+        CreateECalEndcapCellsCfg (flags,
+                                  'CreatePositionedECalEndcapCellsWithNoise',
+                                  addNoise = True,
+                                  cellsNameSuffix = 'WithNoise'))
 
     # ecal endcap cells with noise filtered
-    ecalEndcapCellsNoiseFilteredLinks = ecalEndcapPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
-    createEcalEndcapCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalEndcapCellsWithNoiseFiltered",
-                                                                   doCellCalibration=True,
-                                                                   calibTool=calibEcalEndcap,
-                                                                   positionsTool=cellPositionEcalEndcapTool,
-                                                                   addCrosstalk=False,
-                                                                   crosstalkTool=None,
-                                                                   addCellNoise=True,
-                                                                   filterCellNoise=True,
-                                                                   noiseTool=ecalEndcapNoiseTool,
-                                                                   geometryTool=ecalEndcapGeometryTool,
-                                                                   OutputLevel=INFO,
-                                                                   hits=ecalEndcapReadoutName,  # uncalibrated & unpositioned cells without noise
-                                                                   cells=ecalEndcapPositionedCellsName + "WithNoiseFiltered",
-                                                                   links=ecalEndcapCellsNoiseFilteredLinks
-                                                                   )
-    TopAlg += [createEcalEndcapCellsNoiseFiltered]
+    caldigi_cfg.merge(
+        CreateECalEndcapCellsCfg (flags,
+                                  'CreatePositionedECalEndcapCellsWithNoiseFiltered',
+                                  addNoise = True,
+                                  filterCellNoise = True,
+                                  cellsNameSuffix = 'WithNoiseFiltered'))
 
 if runHCal:
-    # Apply calibration and positioning to cells in HCal barrel
-    hcalBarrelPositionedCellsName = hcalBarrelReadoutName + "Positioned"
-    hcalBarrelLinks = hcalBarrelPositionedCellsName + "SimCaloHitLinks"
-    createHCalBarrelCells = CreatePositionedCaloCells("CreatePositionedHCalBarrelCells",
-                                                      doCellCalibration=True,
-                                                      calibTool=calibHCalBarrel,
-                                                      positionsTool=cellPositionHCalBarrelTool,
-                                                      addCellNoise=False,
-                                                      filterCellNoise=False,
-                                                      hits=hcalBarrelReadoutName,
-                                                      cells=hcalBarrelPositionedCellsName,
-                                                      links=hcalBarrelLinks,
-                                                      OutputLevel=INFO)
-    TopAlg += [createHCalBarrelCells]
+    from FCC_config.ALLEGRO.CreateCaloCellsConfig import \
+         CreateHCalBarrelCellsCfg, CreateHCalEndcapCellsCfg
+    caldigi_cfg.merge(CreateHCalBarrelCellsCfg(flags))
+    caldigi_cfg.merge(CreateHCalEndcapCellsCfg(flags))
 
-    # Apply calibration and positioning to cells in HCal endcap
-    hcalEndcapPositionedCellsName = hcalEndcapReadoutName + "Positioned"
-    hcalEndcapLinks = hcalEndcapPositionedCellsName + "SimCaloHitLinks"
-    createHCalEndcapCells = CreatePositionedCaloCells("CreatePositionedHCalEndcapCells",
-                                                      doCellCalibration=True,
-                                                      calibTool=calibHCalEndcap,
-                                                      addCellNoise=False,
-                                                      filterCellNoise=False,
-                                                      positionsTool=cellPositionHCalEndcapTool,
-                                                      OutputLevel=INFO,
-                                                      hits=hcalEndcapReadoutName,
-                                                      cells=hcalEndcapPositionedCellsName,
-                                                      links=hcalEndcapLinks)
-    TopAlg += [createHCalEndcapCells]
+caldigi_cfg.toVars (TopAlg, ExtSvc)
 
 
 # Muon cells [add longitudinal segmentation to detector?]
@@ -898,6 +584,7 @@ if runMuon:
         OutputLevel=INFO
     )
 
+    from Configurables import CreatePositionedCaloCells
     from Configurables import NoiseCaloCellsFlatTool
     MuonBarrelNoiseTool = NoiseCaloCellsFlatTool("MuonBarrelNoiseTool",
                                                  cellNoiseRMS=0.0005,  # in GeV
@@ -1012,7 +699,7 @@ def setupSWClusters(inputCells,
     caloIDs = []
     for (k, v) in inputCells.items():
         cells.append(v)
-        caloIDs.append(IDs[k])
+        caloIDs.append(detIDs(flags, k))
     # DEBUG
     print("Input cells")
     print(cells)
@@ -1053,7 +740,7 @@ def setupSWClusters(inputCells,
         correctClusterAlg = CorrectCaloClusters("Correct" + outputClusters,
                                                 inClusters=clusterAlg.clusters.Path,
                                                 outClusters="Corrected" + clusterAlg.clusters.Path,
-                                                systemIDs=[IDs["ECAL_Barrel"]],
+                                                systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                 numLayers=[ecalBarrelLayers],
                                                 firstLayerIDs=[0],
                                                 lastLayerIDs=[ecalBarrelLayers - 1],
@@ -1073,7 +760,7 @@ def setupSWClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel"]),
                                                          systemNames=["EMB"],
                                                          numLayers=[ecalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"]],
@@ -1088,7 +775,7 @@ def setupSWClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Endcap"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Endcap"]),
                                                          systemNames=["EMEC"],
                                                          numLayers=[ecalEndcapLayers],
                                                          readoutNames=[inputReadouts["ECAL_Endcap"]],
@@ -1111,7 +798,7 @@ def setupSWClusters(inputCells,
                                                          #thetaFieldNames=["theta"]*4,  # will be ignored for systems!=EMB
                                                          #moduleFieldNames=["module"]*4,  # will be ignored for systems!=EMB
                                                          #thetaRecalcWeights=[ecalBarrelThetaWeights, [-1]*ecalEndcapLayers, [-1]*hcalBarrelLayers, [-1]*hcalEndcapLayers],
-                                                         systemIDs=[IDs["ECAL_Barrel"],IDs["HCAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel","HCAL_Barrel"]),
                                                          systemNames=["EMB", "HCALB"],
                                                          numLayers=[ecalBarrelLayers, hcalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"], inputReadouts["HCAL_Barrel"]],
@@ -1142,7 +829,7 @@ def setupSWClusters(inputCells,
         calibrateClustersAlg = CalibrateCaloClusters("Calibrate" + outputClusters,
                                                      inClusters=inClusters,
                                                      outClusters="Calibrated" + clusterAlg.clusters.Path,
-                                                     systemIDs=[IDs["ECAL_Barrel"]],
+                                                     systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                      systemNames=["EMB"],
                                                      numLayers=[ecalBarrelLayers],
                                                      firstLayerIDs=[0],
@@ -1198,7 +885,7 @@ def setupTopoClusters(inputCells,
     caloIDs = []
     for (k, v) in inputCells.items():
         cells.append(v)
-        caloIDs.append(IDs[k])
+        caloIDs.append(detIDs(flags, k))
 
     # Clustering parameters
     seedSigma = 6
@@ -1239,7 +926,7 @@ def setupTopoClusters(inputCells,
         correctClusterAlg = CorrectCaloClusters("Correct" + outputClusters,
                                                 inClusters=clusterAlg.clusters.Path,
                                                 outClusters="Corrected" + clusterAlg.clusters.Path,
-                                                systemIDs=[IDs["ECAL_Barrel"]],
+                                                systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                 numLayers=[ecalBarrelLayers],
                                                 firstLayerIDs=[0],
                                                 lastLayerIDs=[ecalBarrelLayers - 1],
@@ -1259,7 +946,7 @@ def setupTopoClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Barrel"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Barrel"]),
                                                          systemNames=["EMB"],
                                                          numLayers=[ecalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"]],
@@ -1274,7 +961,7 @@ def setupTopoClusters(inputCells,
                 augmentClusterAlg = AugmentClustersFCCee("Augment" + outputClusters,
                                                          inClusters=clusterAlg.clusters.Path,
                                                          outClusters="Augmented" + clusterAlg.clusters.Path,
-                                                         systemIDs=[IDs["ECAL_Endcap"]],
+                                                         systemIDs=detIDs(flags, ["ECAL_Endcap"]),
                                                          systemNames=["EMEC"],
                                                          numLayers=[ecalEndcapLayers],
                                                          readoutNames=[inputReadouts["ECAL_Endcap"]],
@@ -1297,7 +984,7 @@ def setupTopoClusters(inputCells,
                                                          #thetaFieldNames=["theta"]*4,  # will be ignored for systems!=EMB
                                                          #moduleFieldNames=["module"]*4,  # will be ignored for systems!=EMB
                                                          #thetaRecalcWeights=[ecalBarrelThetaWeights, [-1]*ecalEndcapLayers, [-1]*hcalBarrelLayers, [-1]*hcalEndcapLayers],
-                                                         systemIDs=[IDs["ECAL_Barrel"],IDs["HCAL_Barrel"]],
+                                                         systemIDs=detIDs(flags,["ECAL_Barrel","HCAL_Barrel"]),
                                                          systemNames=["EMB", "HCALB"],
                                                          numLayers=[ecalBarrelLayers, hcalBarrelLayers],
                                                          readoutNames=[inputReadouts["ECAL_Barrel"], inputReadouts["HCAL_Barrel"]],
@@ -1345,7 +1032,7 @@ def setupTopoClusters(inputCells,
         calibrateClustersAlg = CalibrateCaloClusters("Calibrate" + outputClusters,
                                                      inClusters=inClusters,
                                                      outClusters="Calibrated" + clusterAlg.clusters.Path,
-                                                     systemIDs=[IDs["ECAL_Barrel"]],
+                                                     systemIDs=detIDs(flags,["ECAL_Barrel"]),
                                                      systemNames=["EMB"],
                                                      numLayers=[ecalBarrelLayers],
                                                      firstLayerIDs=[0],
@@ -1379,8 +1066,8 @@ def setupTopoClusters(inputCells,
 
 if doSWClustering:
     # SW ECAL barrel clusters
-    EMBCaloClusterInputs = {"ECAL_Barrel": ecalBarrelPositionedCellsName}
-    EMBCaloClusterReadouts = {"ECAL_Barrel": ecalBarrelReadoutName}
+    EMBCaloClusterInputs = {"ECAL_Barrel": flags.ECal.Barrel.cellsName}
+    EMBCaloClusterReadouts = {"ECAL_Barrel": flags.ECal.Barrel.readoutName}
     setupSWClusters(EMBCaloClusterInputs,
                     EMBCaloClusterReadouts,
                     "EMBCaloClusters",
@@ -1391,8 +1078,8 @@ if doSWClustering:
                     runPhotonIDTool)
 
     # SW ECAL endcap clusters
-    EMECCaloClusterInputs = {"ECAL_Endcap": ecalEndcapPositionedCellsName}
-    EMECCaloClusterReadouts = {"ECAL_Endcap": ecalEndcapReadoutName}
+    EMECCaloClusterInputs = {"ECAL_Endcap": flags.ECal.Endcap.cellsName}
+    EMECCaloClusterReadouts = {"ECAL_Endcap": flags.ECal.Endcap.readoutName}
     setupSWClusters(EMECCaloClusterInputs,
                     EMECCaloClusterReadouts,
                     "EMECCaloClusters",
@@ -1404,7 +1091,7 @@ if doSWClustering:
 
     # SW ECAL barrel and endcap clusters with noise
     if addNoise:
-        EMBCaloClusterInputsWithNoise = {"ECAL_Barrel": ecalBarrelPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalBarrelPositionedCellsName + "WithNoiseFiltered"}
+        EMBCaloClusterInputsWithNoise = {"ECAL_Barrel": flags.ECal.Barrel.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Barrel.cellsName + "WithNoiseFiltered"}
         setupSWClusters(EMBCaloClusterInputsWithNoise,
                         EMBCaloClusterReadouts,
                         "EMBCaloClustersWithNoise" if filterNoiseThreshold < 0 else "EMBCaloClustersWithNoiseFiltered",
@@ -1414,7 +1101,7 @@ if doSWClustering:
                         addShapeParameters,
                         runPhotonIDTool)
 
-        EMECCaloClusterInputsWithNoise = {"ECAL_Endcap": ecalEndcapPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalEndcapPositionedCellsName + "WithNoiseFiltered"}
+        EMECCaloClusterInputsWithNoise = {"ECAL_Endcap": flags.ECal.Endcap.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Endcap.cellsName + "WithNoiseFiltered"}
         setupSWClusters(EMECCaloClusterInputsWithNoise,
                         EMECCaloClusterReadouts,
                         "EMECCaloClustersWithNoise" if filterNoiseThreshold < 0 else "EMECCaloClustersWithNoiseFiltered",
@@ -1427,16 +1114,16 @@ if doSWClustering:
     # ECAL + HCAL clusters
     if runHCal:
         CaloClusterInputs = {
-            "ECAL_Barrel": ecalBarrelPositionedCellsName,
-            "ECAL_Endcap": ecalEndcapPositionedCellsName,
-            "HCAL_Barrel": hcalBarrelPositionedCellsName,
-            "HCAL_Endcap": hcalEndcapPositionedCellsName,
+            "ECAL_Barrel": flags.ECal.Barrel.cellsName,
+            "ECAL_Endcap": flags.ECal.Endcap.cellsName,
+            "HCAL_Barrel": flags.HCal.Barrel.cellsName,
+            "HCAL_Endcap": flags.HCal.Endcap.cellsName,
         }
         CaloClusterReadouts = {
-            "ECAL_Barrel": ecalBarrelReadoutName,
-            "ECAL_Endcap": ecalEndcapReadoutName,
-            "HCAL_Barrel": hcalBarrelReadoutName,
-            "HCAL_Endcap": hcalEndcapReadoutName,
+            "ECAL_Barrel": flags.ECal.Barrel.readoutName,
+            "ECAL_Endcap": flags.ECal.Endcap.readoutName,
+            "HCAL_Barrel": flags.HCal.Barrel.readoutName,
+            "HCAL_Endcap": flags.HCal.Endcap.readoutName,
         }
         setupSWClusters(CaloClusterInputs,
                         CaloClusterReadouts,
@@ -1469,8 +1156,8 @@ if doSWClustering:
 
 if doTopoClustering:
     # ECAL barrel topoclusters
-    EMBCaloTopoClusterInputs = {"ECAL_Barrel": ecalBarrelPositionedCellsName}
-    EMBCaloTopoClusterReadouts = {"ECAL_Barrel": ecalBarrelReadoutName}
+    EMBCaloTopoClusterInputs = {"ECAL_Barrel": flags.ECal.Barrel.cellsName}
+    EMBCaloTopoClusterReadouts = {"ECAL_Barrel": flags.ECal.Barrel.readoutName}
     setupTopoClusters(EMBCaloTopoClusterInputs,
                       EMBCaloTopoClusterReadouts,
                       "EMBCaloTopoClusters",
@@ -1483,8 +1170,8 @@ if doTopoClustering:
                       runPhotonIDTool)
 
     # ECAL endcap topoclusters
-    EMECCaloTopoClusterInputs = {"ECAL_Endcap": ecalEndcapPositionedCellsName}
-    EMECCaloTopoClusterReadouts = {"ECAL_Endcap": ecalEndcapReadoutName}
+    EMECCaloTopoClusterInputs = {"ECAL_Endcap": flags.ECal.Endcap.cellsName}
+    EMECCaloTopoClusterReadouts = {"ECAL_Endcap": flags.ECal.Endcap.readoutName}
     setupTopoClusters(EMECCaloTopoClusterInputs,
                       EMECCaloTopoClusterReadouts,
                       "EMECCaloTopoClusters",
@@ -1498,7 +1185,7 @@ if doTopoClustering:
 
     # ECAL topoclusters with noise
     if addNoise:
-        EMBCaloTopoClusterInputsWithNoise = {"ECAL_Barrel": ecalBarrelPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalBarrelPositionedCellsName + "WithNoiseFiltered"}
+        EMBCaloTopoClusterInputsWithNoise = {"ECAL_Barrel": flags.ECal.Barrel.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Barrel.cellsName + "WithNoiseFiltered"}
         setupTopoClusters(EMBCaloTopoClusterInputsWithNoise,
                           EMBCaloTopoClusterReadouts,
                           "EMBCaloTopoClustersWithNoise" if filterNoiseThreshold < 0 else "EMBCaloTopoClustersWithNoiseFiltered",
@@ -1510,7 +1197,7 @@ if doTopoClustering:
                           addShapeParameters,
                           runPhotonIDTool)
 
-        EMECCaloTopoClusterInputsWithNoise = {"ECAL_Endcap": ecalEndcapPositionedCellsName + "WithNoise" if filterNoiseThreshold < 0 else ecalEndcapPositionedCellsName + "WithNoiseFiltered"}
+        EMECCaloTopoClusterInputsWithNoise = {"ECAL_Endcap": flags.ECal.Endcap.cellsName + "WithNoise" if filterNoiseThreshold < 0 else flags.ECal.Endcap.cellsName + "WithNoiseFiltered"}
         setupTopoClusters(EMECCaloTopoClusterInputsWithNoise,
                           EMECCaloTopoClusterReadouts,
                           "EMECCaloTopoClustersWithNoise" if filterNoiseThreshold < 0 else "EMECCaloTopoClustersWithNoiseFiltered",
@@ -1525,16 +1212,16 @@ if doTopoClustering:
     # ECAL + HCAL
     if runHCal:
         CaloTopoClusterInputs = {
-            "ECAL_Barrel": ecalBarrelPositionedCellsName,
-            "ECAL_Endcap": ecalEndcapPositionedCellsName,
-            "HCAL_Barrel": hcalBarrelPositionedCellsName,
-            "HCAL_Endcap": hcalEndcapPositionedCellsName,
+            "ECAL_Barrel": flags.ECal.Barrel.cellsName,
+            "ECAL_Endcap": flags.ECal.Endcap.cellsName,
+            "HCAL_Barrel": flags.HCal.Barrel.cellsName,
+            "HCAL_Endcap": flags.HCal.Endcap.cellsName,
         }
         CaloTopoClusterReadouts = {
-            "ECAL_Barrel": ecalBarrelReadoutName,
-            "ECAL_Endcap": ecalEndcapReadoutName,
-            "HCAL_Barrel": hcalBarrelReadoutName,
-            "HCAL_Endcap": hcalEndcapReadoutName,
+            "ECAL_Barrel": flags.ECal.Barrel.readoutName,
+            "ECAL_Endcap": flags.ECal.Endcap.readoutName,
+            "HCAL_Barrel": flags.HCal.Barrel.readoutName,
+            "HCAL_Endcap": flags.HCal.Endcap.readoutName,
         }
         # note: the neighbour map links ecal and hcal barrels, and hcal barrel-endcap, but does not link (yet) the others
         setupTopoClusters(CaloTopoClusterInputs,
@@ -1552,9 +1239,9 @@ if doTopoClustering:
 # Create CaloHit<->MCParticle links (needed for training datasets for MLPF)
 # Also store Cluster<->MCParticle links (for truth matching for efficiency and purity studies)
 from Configurables import CreateTruthLinks
-caloLinks = [ecalBarrelLinks, ecalEndcapLinks]
+caloLinks = [flags.ECal.Barrel.linksName, flags.ECal.Endcap.linksName]
 if runHCal:
-    caloLinks += [hcalBarrelLinks, hcalEndcapLinks]
+    caloLinks += [flags.HCal.Barrel.linksName, flags.HCal.Endcap.linksName]
 if runMuon:
     caloLinks += [muonBarrelLinks, muonEndcapLinks]
 createTruthLinks = CreateTruthLinks("CreateTruthLinks",
@@ -1575,12 +1262,12 @@ io_svc.outputCommands = ["keep *",
 
 # drop the uncalibrated cells
 if dropUncalibratedCells:
-    io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Barrel.readoutName)
     io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName2)
-    io_svc.outputCommands.append("drop %s" % ecalEndcapReadoutName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Endcap.readoutName)
     if runHCal:
-        io_svc.outputCommands.append("drop %s" % hcalBarrelReadoutName)
-        io_svc.outputCommands.append("drop %s" % hcalEndcapReadoutName)
+        io_svc.outputCommands.append("drop %s" % flags.HCal.Barrel.readoutName)
+        io_svc.outputCommands.append("drop %s" % flags.HCal.Endcap.readoutName)
     else:
         io_svc.outputCommands += ["drop HCal*"]
 
@@ -1606,18 +1293,18 @@ if dropMuonHits:
 
 # drop hits/positioned cells/cluster cells if desired
 if not saveHits:
-    io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop *%sContributions" % flags.ECal.Barrel.readoutName)
     io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName2)
-    io_svc.outputCommands.append("drop *%sContributions" % ecalEndcapReadoutName)
+    io_svc.outputCommands.append("drop *%sContributions" % flags.ECal.Endcap.readoutName)
     if runHCal:
-        io_svc.outputCommands.append("drop *%sContributions" % hcalBarrelReadoutName)
-        io_svc.outputCommands.append("drop *%sContributions" % hcalEndcapReadoutName)
+        io_svc.outputCommands.append("drop *%sContributions" % flags.HCal.Barrel.readoutName)
+        io_svc.outputCommands.append("drop *%sContributions" % flags.HCal.Endcap.readoutName)
 if not saveCells:
-    io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName)
-    io_svc.outputCommands.append("drop %s" % ecalEndcapPositionedCellsName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Barrel.cellsName)
+    io_svc.outputCommands.append("drop %s" % flags.ECal.Endcap.cellsName)
     if addNoise:
-        io_svc.outputCommands.append("drop %sWithNoise*" % ecalBarrelPositionedCellsName)
-        io_svc.outputCommands.append("drop %sWithNoise*" % ecalEndcapPositionedCellsName)
+        io_svc.outputCommands.append("drop %sWithNoise*" % flags.ECal.Barrel.cellsName)
+        io_svc.outputCommands.append("drop %sWithNoise*" % flags.ECal.Endcap.cellsName)
     if resegmentECalBarrel:
         io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName2)
     if runHCal:

--- a/python/FCC_config/ALLEGRO/CreateCaloCellsConfig.py
+++ b/python/FCC_config/ALLEGRO/CreateCaloCellsConfig.py
@@ -1,0 +1,653 @@
+#
+# File: python/FCC_config/ALLEGRO/CreateCaloCellsConfig.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Jun, 2026
+# Purpose: ALLEGRO job configuration functions for creating calorimeter cells.
+#
+# ComponentAccumulator style configuration functions for ALLEGRO calorimeter
+# cell making.
+#
+# Here is an example of using these to configure cell reconstruction for
+# both ECal and HCAL with default parameters:
+#
+#    class Flags:
+#        pass
+#    flags = Flags()
+#    flags.compactFile = os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml"
+#    from FCC_config.ALLEGRO.CreateCaloCellsConfig import defineCaloCellFlags
+#    defineCaloCellFlags(flags)
+#
+#    from FCC_config.ComponentAccumulator import ComponentAccumulator
+#    caldigi_cfg = ComponentAccumulator()
+#    from FCC_config.ALLEGRO.CreateCaloCellsConfig import \
+#      CreateECalBarrelCellsCfg, CreateECalBarrelCellsCfg, \
+#      CreateHCalBarrelCellsCfg, CreateHCalEndcapCellsCfg
+#    caldigi_cfg.merge(CreateECalBarrelCellsCfg(flags))
+#    caldigi_cfg.merge(CreateECalEndcapCellsCfg(flags))
+#    caldigi_cfg.merge(CreateHCalBarrelCellsCfg(flags))
+#    caldigi_cfg.merge(CreateHCalEndcapCellsCfg(flags))
+#
+#    caldigi_cfg.toVars (TopAlg, ExtSvc)
+#
+# The behavior can be changed via arguments to the above functions.
+# For example, to enable noise and crosstalk:
+#
+#    caldigi_cfg.merge(CreateECalBarrelCellsCfg(flags,
+#                                               name = 'ECalCellsWithNoise',
+#                                               addNoise = True,
+#                                               addCrosstalk = True,
+#                                               cellsNameSuffix = 'WithNoise'))
+#
+# Some defaults can also be overridden via the flags object.
+# See the code for details.
+#
+
+
+from FCC_config.ComponentAccumulator import ComponentAccumulator
+import Configurables as C
+from FCC_config.DetIDs import detIDs
+
+
+# ECAL barrel parameters for digitization
+ecalBarrelLayers = 11
+
+# e-, 10 GeV, flat theta, B field off
+# ecalBarrelSamplingFraction = [0.3800493723322256,  #  0
+#                               0.13494147915064658, #  1
+#                               0.142866851721152,   #  2
+#                               0.14839315921940666, #  3
+#                               0.15298362570665006, #  4
+#                               0.15709704561942747, #  5
+#                               0.16063717490147533, #  6
+#                               0.1641723795419055,  #  7
+#                               0.16845490287689746, #  8
+#                               0.17111520115997653, #  9
+#                               0.1730605163148862,  # 10
+#                               ]
+
+#  e-, 20 GeV, flat theta, B field on; LAr+Pb
+ecalBarrelSamplingFraction = [0.3790943904011486,  #  0
+                              0.1355600584387894,  #  1
+                              0.14628210607758893, #  2
+                              0.15274136994224854, #  3
+                              0.15817255837886351, #  4
+                              0.16290355087527258, #  5
+                              0.1674201708055751,  #  6
+                              0.1715846423182708,  #  7
+                              0.17558662106635545, #  8
+                              0.18002243792463576, #  9
+                              0.18288329976007917, # 10
+                              ]
+
+# LKr+W
+# ecalBarrelSamplingFraction = [0.4806159038189229,  #  0
+#                               0.2822724529941907,  #  1
+#                               0.29324811578621524, #  2
+#                               0.2996356722403102,  #  3
+#                               0.3047116566166906,  #  4
+#                               0.3090324459212472,  #  5
+#                               0.3133282052725273,  #  6
+#                               0.3173868504112048,  #  7
+#                               0.3215311396527887,  #  8
+#                               0.32516920330802673, #  9
+#                               0.3318488881234955,  # 10
+#                               ]
+
+ecalBarrelUpstreamParameters = [[0.028158491043365624,
+                                 -1.564259408365951,
+                                 -76.52312805346982,
+                                 0.7442903558010191,
+                                 -34.894692961350195,
+                                 -74.19340877431723]]
+ecalBarrelDownstreamParameters = [[0.00010587711361028165,
+                                   0.0052371999097777355,
+                                   0.69906696456064,
+                                   -0.9348243433360095,
+                                   -0.0364714212117143,
+                                   8.360401126995626]]
+
+
+if ecalBarrelSamplingFraction and len(ecalBarrelSamplingFraction) > 0:
+    assert (ecalBarrelLayers == len(ecalBarrelSamplingFraction))
+
+
+# ECAL endcap parameters for digitization
+ecalEndcapWheels = 3
+
+# the turbine endcap has calibration "layers" in the both the z and radial
+# directions, for each of the three wheels.  So the total number of layers
+# is given by:
+#
+#   ECalEndcapNumCalibZLayersWheel1*ECalEndcapNumCalibRhoLayersWheel1
+#  +ECalEndcapNumCalibZLayersWheel2*ECalEndcapNumCalibRhoLayersWheel2
+#  +ECalEndcapNumCalibZLayersWheel3*ECalEndcapNumCalibRhoLayersWheel3
+#
+# which in the current design is 5*10+1*14+1*34 = 98
+# NB some cells near the inner and outer edges of the calorimeter are difficult
+# to calibrate as they are not part of the core of well-contained showers.
+# The calibrated values can be <0 or >1 for such cells, so these nonsensical
+# numbers are replaced by 1
+ecalEndcapLayers = 98
+ecalEndcapSamplingFraction = [
+    0.0897818,  0.221318,   0.0820002, 0.994281, 0.0414437, # 0  wheel 1 zlay 0
+    0.1148,     0.178831,   0.142449,  0.181206, 0.342843,  # 5
+    0.137479,   0.176479,   0.153273,  0.195836, 0.0780405, # 10 wheel 1 zlay 1
+    0.150202,   0.17846,    0.164886,  0.175758, 0.10836,   # 15
+    0.160243,   0.183373,   0.171818,  0.194848, 0.111899,  # 20 wheel 1 zlay 2
+    0.170704,   0.188455,   0.178164,  0.209113, 0.105241,  # 25
+    0.180637,   0.192206,   0.186096,  0.211962, 0.112019,  # 30 wheel 1 zlay 3
+    0.180344,   0.195684,   0.190778,  0.218259, 0.118516,  # 35
+    0.207786,   0.204474,   0.207048,  0.225913, 0.111325,  # 40 wheel 1 zlay 4
+    0.147875,   0.195625,   0.173326,  0.175449, 0.104087,  # 45
+    0.153645,   0.161263,   0.165499,  0.171758, 0.175789,  # 50 wheel 2
+    0.180657,   0.184563,   0.187876,  0.191762, 0.19426,   # 55
+    0.197959,   0.199021,   0.204428,  0.195709,            # 60
+    0.151751,   0.171477,   0.165509,  0.172565, 0.172961,  # 64 wheel 3
+    0.175534,   0.177989,   0.18026,   0.181898, 0.183912,  # 69
+    0.185654,   0.187515,   0.190408,  0.188794, 0.193699,  # 74
+    0.192287,   0.19755,    0.190943,  0.218553, 0.161085,  # 79
+    0.373086,   0.122495,   0.21103,   1,        0.138686,  # 84
+    0.0545171,  1,          1,         0.227945, 0.0122872, # 89
+    0.00437334, 0.00363533, 1,         1,                   # 94
+    ]
+if ecalEndcapSamplingFraction and len(ecalEndcapSamplingFraction) > 0:
+    assert (ecalEndcapLayers == len(ecalEndcapSamplingFraction))
+
+
+hcalBarrelLayers = 13
+hcalEndcapLayers = 22
+
+    
+def ECalBarrelGeometryTool (flags, name = 'ECalBarrelGeometryTool',
+                            readoutName = None):
+    """Return calorimeter tool for ECal barrel.
+
+Use the default readout if readoutName is not supplied."""
+
+    if readoutName is None: readoutName = flags.ECal.Barrel.readoutName
+    return C.TubeLayerModuleThetaCaloTool(name,
+                                          readoutName=readoutName,
+                                          activeVolumeName="LAr_sensitive",
+                                          activeFieldName="layer",
+                                          activeVolumesNumber=ecalBarrelLayers,
+                                          fieldNames=["system"],
+                                          fieldValues=[detIDs(flags, 'ECAL_Barrel')],
+                                          )
+
+
+def ECalEndcapGeometryTool (flags, name = 'ECalEndcapGeometryTool',
+                            readoutName = None):
+    """Return calorimeter tool for ECal endcap.
+
+Use the default readout if readoutName is not supplied."""
+    
+    if readoutName is None: readoutName = flags.ECal.Endcap.readoutName
+    return C.TurbineEndcapCaloTool (name,
+                                    readoutName=readoutName)
+
+
+def HCalBarrelGeometryTool (flags, name = 'HCalBarrelGeometryTool',
+                            readoutName = None):
+    """Return calorimeter tool for HCal barrel.
+
+Use the default readout if readoutName is not supplied."""
+    
+    if readoutName is None: readoutName = flags.HCal.Barrel.readoutName
+    return C.HCalPhiThetaCaloTool(name,
+                                  readoutName=readoutName)
+
+
+def HCalEndcapGeometryTool (flags, name = 'HCalEndcapGeometryTool',
+                            readoutName = None):
+    """Return calorimeter tool for HCal endcap.
+
+Use the default readout if readoutName is not supplied."""
+    
+    if readoutName is None: readoutName = flags.HCal.Endcap.readoutName
+    return C.HCalPhiThetaCaloTool(name,
+                                  readoutName=readoutName)
+
+
+class CaloCellIndexerSvc:
+    """Helper to handle merging of CaloCellIndexerSvc."""
+    def __init__ (self, name, GeoTools = []):
+        self._name = name
+        self.GeoTools = GeoTools
+        return
+    def name (self):
+        return self._name
+
+    def mergeTo (self, old):
+        if not isinstance (old, CaloCellIndexerSvc): return False
+        oldnames = [x.name() for x in old.GeoTools]
+        for tool in self.GeoTools:
+            if tool.name() not in oldnames:
+                old.GeoTools.append (tool)
+        return True
+
+    def convertTo (self):
+        return C.k4__recCalo__CaloCellIndexerSvc (self.name(),
+                                                  GeoTools = self.GeoTools)
+
+
+def CaloCellIndexerSvcCfg (flags,
+                           name = 'k4::recCalo::CaloCellIndexerSvc',
+                           detectors = [],
+                           tools = []):
+    """Return CA for an indexer service for a given set of geometry tools.
+
+The detectors argument is a list of subdirectory names for which to create
+geometry tools.  Any explicitly given by the tools argument will also be
+added.
+"""
+    _geometry_tools = {
+        'ECAL_Barrel' : ECalBarrelGeometryTool,
+        'ECAL_Endcap' : ECalEndcapGeometryTool,
+        'HCAL_Barrel' : HCalBarrelGeometryTool,
+        'HCAL_Endcap' : HCalEndcapGeometryTool,
+    }
+    cfg = ComponentAccumulator()
+    tools = tools[:]
+    for d in detectors:
+        tools.append (_geometry_tools[d](flags))
+    svc = CaloCellIndexerSvc (name, GeoTools = tools)
+    cfg.addSvc (svc)
+    return cfg
+
+
+def CalibrateECalBarrel (flags, name = 'CalibrateECalBarrel'):
+    """Return tool to calibrate ECal barrel cells."""
+    return C.CalibrateInLayersTool(name,
+                                   samplingFraction=ecalBarrelSamplingFraction,
+                                   readoutName=flags.ECal.Barrel.readoutName,
+                                   layerFieldName="layer")
+
+
+def CalibrateECalEndcap (flags, name = 'CalibrateECalEndcap'):
+    """Return tool to calibrate ECal endcap cells."""
+    return C.CalibrateInLayersTool(name,
+                                   samplingFraction=ecalEndcapSamplingFraction,
+                                   readoutName=flags.ECal.Endcap.readoutName,
+                                   layerFieldName="layer")
+
+
+def CalibrateHCalBarrel (flags, name = 'CalibrateHCalBarrel'):
+    """Return tool to calibrate HCal barrel cells."""
+    return C.CalibrateCaloHitsTool(name,
+                                   invSamplingFraction=29.4202)
+
+
+def CalibrateHCalEndcap (flags, name = 'CalibrateHCalEndcap'):
+    """Return tool to calibrate HCal endcap cells."""
+    return C.CalibrateCaloHitsTool(name,
+                                   invSamplingFraction=29.4202)  # FIXME: to be updated for ddsim
+
+
+def CellPositionsECalBarrel (flags,
+                             name = 'CellPositionsECalBarrel',
+                             readoutName = None):
+    """Return tool to calculate cell positions for ECal barrel."""
+    if readoutName is None: readoutName = flags.ECal.Barrel.readoutName
+    return C.CellPositionsECalBarrelModuleThetaSegTool(name,
+                                                       readoutName=readoutName)
+
+
+def CellPositionsECalEndcap (flags,
+                             name = 'CellPositionsECalEndcap',
+                             readoutName = None):
+    """Return tool to calculate cell positions for ECal endcap."""
+    if readoutName is None: readoutName = flags.ECal.Endcap.readoutName
+    return C.CellPositionsECalEndcapTurbineSegTool(name,
+                                                   readoutName=readoutName)
+
+
+def CellPositionsHCalBarrel (flags,
+                             name = 'CellPositionsHCalBarrel',
+                             readoutName = None):
+    """Return tool to calculate cell positions for HCal barrel."""
+    if readoutName is None: readoutName = flags.HCal.Barrel.readoutName
+    return C.CellPositionsHCalPhiThetaSegTool(name,
+                                              readoutName=readoutName,
+                                              detectorName='HCalBarrel')
+
+
+def CellPositionsHCalEndcap (flags,
+                             name = 'CellPositionsHCalEndcap',
+                             readoutName = None):
+    """Return tool to calculate cell positions for HCal endcap."""
+    if readoutName is None: readoutName = flags.HCal.Endcap.readoutName
+    return C.CellPositionsHCalPhiThetaSegTool(name,
+                                              readoutName=readoutName,
+                                              detectorName='HCalThreePartsEndcap',
+                                              numLayersHCalThreeParts=[6, 9, 22])
+
+
+def ReadCrosstalkMapECalBarrel (flags, name = 'ReadCrosstalkMapECalBarrel'):
+    """Return crosstalk tool for ECal barrel"""
+    return C.ReadCaloCrosstalkMap(name,
+                                  #detID = detIDs(flags, 'ECAL_Barrel'),
+                                  fileName = flags.ECal.Barrel.xtalkPath)
+
+
+def ECalBarrelNoiseTool (flags, name = 'ECalBarrelNoiseTool'):
+    """Return noise tool for ECal barrel."""
+    return C.NoiseCaloCellsFromFileBarrelTool (name,
+                                               cellPositionsTool=CellPositionsECalBarrel(flags),
+                                               readoutName=flags.ECal.Barrel.readoutName,
+                                               noiseFileName=flags.ECal.Barrel.noisePath,
+                                               elecNoiseRMSHistoName=flags.ECal.Barrel.noiseRMSHistName,
+                                               setNoiseOffset=False,
+                                               activeFieldName="layer",
+                                               addPileup=False,
+                                               filterNoiseThreshold=flags.ECal.Barrel.filterNoiseThreshold,
+                                               useAbsInFilter=True,
+                                               numHistograms=ecalBarrelLayers,
+                                               scaleFactor=1 / 1000.,  # MeV to GeV
+                                               )
+
+
+def ECalEndcapNoiseTool (flags, name = 'ECalEndcapNoiseTool'):
+    """Return noise tool for ECal endcap."""
+    return C.NoiseCaloCellsFromFileTurbineEndcapTool (name,
+                                                      cellPositionsTool=CellPositionsECalEndcap(flags),
+                                                      readoutName=flags.ECal.Endcap.readoutName,
+                                                      noiseFileName=flags.ECal.Endcap.noisePath,
+                                                      elecNoiseRMSHistoName=flags.ECal.Endcap.noiseRMSHistName,
+                                                      setNoiseOffset=False,
+                                                      activeFieldName="wheel",
+                                                      addPileup=False,
+                                                      filterNoiseThreshold=flags.ECal.Endcap.filterNoiseThreshold,
+                                                      useAbsInFilter=True,
+                                                      numHistograms=ecalEndcapWheels, # 3 wheels
+                                                      scaleFactor=1 / 1000.,  # MeV to GeV
+                                               )
+
+
+def CreateECalBarrelCellsCfg (flags,
+                              name = 'CreatePositionedECalBarrelCells',
+                              doCellCalibration = True,
+                              addNoise = False,
+                              addCrosstalk = None,
+                              filterCellNoise = False,
+                              cellsNameSuffix = '',
+                              hits = None,
+                              readoutName = None,
+                              alg = C.CreatePositionedCaloCells,
+                              **kw):
+    """Return a CA for creating ECal barrel cells.
+
+doCellCalibration controls whether sampling-faction calibration is applied.
+addNoise and addCrosstalk control the addition of noise and crosstalk,
+while filterCellNoise enables filtering cells with small energy.
+Hits are taken from the container given by the hits argumnent, defaulting
+to the ECal barrel readout name if not supplied.
+If cellsNameSuffix is specified, this will be added to the end of the
+output cell container.
+The readout name may be overridden using the readoutName argument.
+Passing alg allows overriding the algorithm type used for the reconstruction.
+"""
+
+    cfg = ComponentAccumulator()
+    cfg.merge (CaloCellIndexerSvcCfg (flags, detectors = ['ECAL_Barrel']))
+    if hits is None: hits = flags.ECal.Barrel.readoutName
+    if readoutName is None: readoutName = flags.ECal.Barrel.readoutName
+    if addCrosstalk is None: addCrosstalk = flags.ECal.Barrel.addCrosstalk
+
+    kw.setdefault('cells', readoutName + flags.cellsNamePart + cellsNameSuffix)
+    kw.setdefault('links', kw['cells'] + flags.linksNamePart)
+
+    kw.setdefault('calibTool', CalibrateECalBarrel(flags) if doCellCalibration else None)
+    if addCrosstalk:
+        kw['crosstalkTool'] = ReadCrosstalkMapECalBarrel(flags)
+    else:
+        kw['crosstalkTool'] = None
+       
+    kw.setdefault('crosstalkTool', ReadCrosstalkMapECalBarrel(flags) if addCrosstalk else None)
+    kw.setdefault('noiseTool', ECalBarrelNoiseTool(flags) if addNoise else None)
+    kw.setdefault('geometryTool', ECalBarrelGeometryTool(flags) if addNoise else None)
+
+    if hits == flags.ECal.Barrel.readoutName:
+        kw['positionsTool'] = CellPositionsECalBarrel(flags)
+    else:
+        kw['positionsTool'] = CellPositionsECalBarrel(flags,
+                                                      name='CellPositions' + readoutName,
+                                                      readoutName=readoutName)
+
+    cfg.addAlg(alg(name,
+                   hits=hits,
+                   doCellCalibration=doCellCalibration,
+                   addCrosstalk=addCrosstalk,
+                   addCellNoise=addNoise,
+                   filterCellNoise=filterCellNoise,
+                   **kw
+                   ))
+    return cfg
+                           
+
+def CreateECalEndcapCellsCfg (flags,
+                              name = 'CreatePositionedECalEndcapCells',
+                              doCellCalibration = True,
+                              addNoise = False,
+                              filterCellNoise = False,
+                              cellsNameSuffix = '',
+                              hits = None,
+                              readoutName = None,
+                              alg = C.CreatePositionedCaloCells,
+                              **kw):
+    """Return a CA for creating ECal endcap cells.
+
+doCellCalibration controls whether sampling-faction calibration is applied.
+Hits are taken from the container given by the hits argumnent, defaulting
+to the ECal endcap readout name if not supplied.
+If cellsNameSuffix is specified, this will be added to the end of the
+output cell container.
+Passing alg allows overriding the algorithm type used for the reconstruction.
+"""
+    cfg = ComponentAccumulator()
+    cfg.merge (CaloCellIndexerSvcCfg (flags, detectors = ['ECAL_Endcap']))
+    if readoutName is None: readoutName = flags.ECal.Endcap.readoutName
+    if hits is None: hits = flags.ECal.Endcap.readoutName
+
+    kw.setdefault('cells', readoutName + flags.cellsNamePart + cellsNameSuffix)
+    kw.setdefault('links', kw['cells'] + flags.linksNamePart)
+
+    kw.setdefault('noiseTool', ECalEndcapNoiseTool(flags) if addNoise else None)
+    kw.setdefault('geometryTool', ECalEndcapGeometryTool(flags) if addNoise else None)
+
+    kw.setdefault('calibTool', CalibrateECalEndcap(flags) if doCellCalibration else None)
+
+    if hits == flags.ECal.Endcap.readoutName:
+        kw['positionsTool'] = CellPositionsECalEndcap(flags)
+    else:
+        kw['positionsTool'] = CellPositionsECalEndcap(flags,
+                                                      name='CellPositions' + readoutName,
+                                                      readoutName=readoutName)
+
+    cfg.addAlg(alg(name,
+                   hits=hits,
+                   doCellCalibration=doCellCalibration,
+                   addCellNoise=addNoise,
+                   addCrosstalk=False,
+                   filterCellNoise=filterCellNoise,
+                   crosstalkTool=None,
+                   **kw
+                   ))
+
+    return cfg
+
+
+def CreateHCalBarrelCellsCfg (flags,
+                              name = 'CreatePositionedHCalBarrelCells',
+                              doCellCalibration = True,
+                              cellsNameSuffix = '',
+                              hits = None,
+                              alg = C.CreatePositionedCaloCells,
+                              **kw):
+    """Return a CA for creating HCal barrel cells.
+
+doCellCalibration controls whether sampling-faction calibration is applied.
+Hits are taken from the container given by the hits argumnent, defaulting
+to the HCal barrel readout name if not supplied.
+If cellsNameSuffix is specified, this will be added to the end of the
+output cell container.
+Passing alg allows overriding the algorithm type used for the reconstruction.
+"""
+    cfg = ComponentAccumulator()
+    cfg.merge (CaloCellIndexerSvcCfg (flags, detectors = ['HCAL_Barrel']))
+    if hits is None: hits = flags.HCal.Barrel.readoutName
+
+    kw.setdefault('cells', hits + flags.cellsNamePart + cellsNameSuffix)
+    kw.setdefault('links', kw['cells'] + flags.linksNamePart)
+
+    kw.setdefault('calibTool', CalibrateHCalBarrel(flags) if doCellCalibration else None)
+
+    cfg.addAlg(alg(name,
+                   hits=hits,
+                   doCellCalibration=doCellCalibration,
+                   positionsTool=CellPositionsHCalBarrel(flags),
+                   addCellNoise=False,
+                   noiseTool=None,
+                   addCrosstalk=False,
+                   filterCellNoise=False,
+                   crosstalkTool=None,
+                   **kw
+                   ))
+    return cfg
+
+
+def CreateHCalEndcapCellsCfg (flags,
+                              name = 'CreatePositionedHCalEndcapCells',
+                              doCellCalibration = True,
+                              cellsNameSuffix = '',
+                              hits = None,
+                              alg = C.CreatePositionedCaloCells,
+                              **kw):
+    """Return a CA for creating HCal endcap cells.
+
+doCellCalibration controls whether sampling-faction calibration is applied.
+Hits are taken from the container given by the hits argumnent, defaulting
+to the HCal endcap readout name if not supplied.
+If cellsNameSuffix is specified, this will be added to the end of the
+output cell container.
+Passing alg allows overriding the algorithm type used for the reconstruction.
+"""
+    cfg = ComponentAccumulator()
+    cfg.merge (CaloCellIndexerSvcCfg (flags, detectors = ['HCAL_Endcap']))
+    if hits is None: hits = flags.HCal.Endcap.readoutName
+
+    kw.setdefault('cells', hits + flags.cellsNamePart + cellsNameSuffix)
+    kw.setdefault('links', kw['cells'] + flags.linksNamePart)
+
+    kw.setdefault('calibTool', CalibrateHCalEndcap(flags) if doCellCalibration else None)
+
+    cfg.addAlg(alg(name,
+                   hits=hits,
+                   doCellCalibration=doCellCalibration,
+                   positionsTool=CellPositionsHCalEndcap(flags),
+                   addCellNoise=False,
+                   noiseTool=None,
+                   addCrosstalk=False,
+                   filterCellNoise=False,
+                   crosstalkTool=None,
+                   **kw
+                   ))
+    return cfg
+
+
+                           
+def ReSegmentationECalBarrelCfg(flags,
+                                name = 'ReSegmentationEcal',
+                                newReadoutName = 'ECalBarrelModuleThetaMerged2',
+                                newCellsName = 'ECalBarrelCellsMerged'):
+    """Rewrite ECal barrel cells with a new segmentation."""
+
+    cfg = ComponentAccumulator()
+    cfg.addAlg(C.RedoSegmentation(name,
+                                  # old bitfield (readout)
+                                  oldReadoutName=flags.ECal.Barrel.readoutName,
+                                  # specify which fields are going to be altered (deleted/rewritten)
+                                  oldSegmentationIds=['module', 'theta'],
+                                  # new bitfield (readout), with new segmentation (merged modules and theta cells)
+                                  newReadoutName=newReadoutName,
+                                  debugPrint=200,
+                                  inhits=flags.ECal.Barrel.readoutName + flags.cellsNamePart,
+                                  outhits=newCellsName))
+    return cfg
+
+
+
+class Flags:
+    """Dummy class to hold configuration flags."""
+    pass
+
+
+def defineCaloCellFlags(flags = None,
+                        cellsNamePart = 'Positioned',
+                        linksNamePart = 'SimCaloHitLinks'):
+    """Define configuration flags for calorimeter cell reconstruction.
+
+    If a top-level flags object is given as the first argument,
+    flags will be added to it.  Otherwise, a new top-level flags
+    object will be created.  In any case, the top-level flags
+    are returned.
+
+    cellsNamePart is a suffix to add to the readout name to get the
+    cell container names; linksNamePart is a suffix added to the cell
+    container names to get the link names.
+
+    If defined, flags.dataFiles is used as the path to data files.
+
+    Creates flags sub-objects ECal.Barrel, ECal.Endcap, HCal.Barrel, HCal.Endcap.
+    """
+
+    # Create top-level object if not provided.
+    if flags is None:
+        flags = Flags()
+
+    # Container name suffixes.
+    flags.cellsNamePart = cellsNamePart
+    flags.linksNamePart = linksNamePart
+
+    # dataFiles defaults to null.
+    dataFiles = getattr (flags, 'dataFiles', '')
+
+    flags.ECal = Flags()
+    flags.HCal = Flags()
+
+    # ECal barrel
+    flags.ECal.Barrel = Flags()
+    flags.ECal.Barrel.readoutName = 'ECalBarrelModuleThetaMerged'      # barrel, original segmentation (baseline)
+    flags.ECal.Barrel.cellsName = flags.ECal.Barrel.readoutName + flags.cellsNamePart
+    flags.ECal.Barrel.linksName = flags.ECal.Barrel.cellsName + flags.linksNamePart
+    flags.ECal.Barrel.addCrosstalk = False
+    flags.ECal.Barrel.noisePath = dataFiles + "elecNoise_ecalBarrelFCCee_theta.root"
+    flags.ECal.Barrel.xtalkPath = dataFiles + "xtalk_neighbours_map_ecalB_thetamodulemerged.root"
+    flags.ECal.Barrel.noiseRMSHistName = 'h_elecNoise_fcc_'
+    flags.ECal.Barrel.filterNoiseThreshold = -1
+
+    # ECal endcap
+    flags.ECal.Endcap = Flags()
+    flags.ECal.Endcap.readoutName = 'ECalEndcapTurbine'                # endcap, turbine-like (baseline)
+    flags.ECal.Endcap.cellsName = flags.ECal.Endcap.readoutName + flags.cellsNamePart
+    flags.ECal.Endcap.linksName = flags.ECal.Endcap.cellsName + flags.linksNamePart
+    flags.ECal.Endcap.noisePath = dataFiles + "elecNoise_ecalendcap.root"
+    flags.ECal.Endcap.noiseRMSHistName = 'noise_endcap_wheel'
+    flags.ECal.Endcap.filterNoiseThreshold = -1
+
+    # HCal barrel
+    flags.HCal.Barrel = Flags()
+    flags.HCal.Barrel.readoutName = 'HCalBarrelReadout'            # barrel, original segmentation (phi-theta)
+    #flags.HCal.Barrel.readoutName = 'HCalBarrelReadoutPhiRow'    # barrel, alternative segmentation (phi-row)
+    flags.HCal.Barrel.cellsName = flags.HCal.Barrel.readoutName + flags.cellsNamePart
+    flags.HCal.Barrel.linksName = flags.HCal.Barrel.cellsName + flags.linksNamePart
+
+    # HCal endcap
+    flags.HCal.Endcap = Flags()
+    flags.HCal.Endcap.readoutName = 'HCalEndcapReadout'            # endcap, original segmentation
+    #flags.HCal.Endcap.readoutName = 'HCalEndcapReadoutPhiRow'    # endcap, alternative segmentation (phi-row)
+    flags.HCal.Endcap.cellsName = flags.HCal.Endcap.readoutName + flags.cellsNamePart
+    flags.HCal.Endcap.linksName = flags.HCal.Endcap.cellsName + flags.linksNamePart
+
+    return flags
+
+    

--- a/python/FCC_config/ComponentAccumulator.py
+++ b/python/FCC_config/ComponentAccumulator.py
@@ -1,5 +1,5 @@
 #
-# File: python/FCC_config.ComponentAccumulator.py
+# File: python/FCC_config/ComponentAccumulator.py
 # Author: scott snyder <snyder@bnl.gov>
 # Date: Feb, 2026
 # Purpose: ComponentAccumulator-style configuration for key4hep.

--- a/python/FCC_config/DetIDs.py
+++ b/python/FCC_config/DetIDs.py
@@ -1,0 +1,66 @@
+#
+# File: python/FCC_config/DetIDs.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Jun, 2026
+# Purpose: Helper to translate detector names to IDs.
+#
+# Works by reading the DetID constants from DectDimentions.xml.
+#
+
+import xml.etree.ElementTree as ET
+import os
+
+# All dictionaries we've read.
+# Indexed by the compact file name, gives a dictionary of name->ID mappings.
+_allDicts = {}
+
+def _makeIdDict (flags):
+    """Read detector ID mappings.
+
+The file to read is found by looking for DectDimentions.xml in the same
+directory as flags.compactFile."""    
+
+    # Find and read the XML file.
+    pathToDetector = os.path.dirname (flags.compactFile)
+    xmlfile = os.path.join (pathToDetector, 'DectDimensions.xml')
+    tree = ET.parse (xmlfile)
+    root = tree.getroot()
+    d = {}
+
+    # Look for DetID constants.
+    for constant in root.find('define').findall('constant'):
+        name = constant.get('name')
+        if name.startswith('DetID'):
+            # Found one.  Find the corresponding ID and enter in the dictionary.
+            val = int(constant.get('value'))
+            d[name[6:]] = val
+
+            # Special case.
+            if name == 'DetID_Muon_Endcap_1':
+                d[name[6:-2]] = val
+    return d
+                
+
+def _detIdDict (flags):
+    """Return the name->ID mapping for a particular compact file.
+
+The configuration used is given by flags.compactFile."""
+
+    compactFile = flags.compactFile
+    if compactFile not in _allDicts:
+        _allDicts[compactFile] = _makeIdDict (flags)
+    return _allDicts[compactFile]
+
+
+def detIDs (flags, ids):
+    """Return detector IDs for a set of names.
+
+ids can either be a single name, in which case a single ID is returned,
+or a list of names, in which case a list of IDs is returned.
+
+The configuration used is given by flags.compactFile."""
+
+    d = _detIdDict (flags)
+    if isinstance(ids, list):
+        return [d[x] for x in ids]
+    return d[ids]

--- a/python/test/ALLEGRO/CreateCaloCellsConfig_test.py
+++ b/python/test/ALLEGRO/CreateCaloCellsConfig_test.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python
+#
+# File: python/test/ALLEGRO/CreateCaloCellsConfig_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Jun, 2026
+# Purpose: Unit tests for ALLEGRO CreateCaloCellsConfig 
+#
+
+import unittest
+import os
+from FCC_config.ALLEGRO import CreateCaloCellsConfig
+
+
+compactFile = os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml"
+
+
+class Flags:
+    pass
+
+class TestCreateCaloCellsConfig (unittest.TestCase):
+    def test_defineCaloCellFlags1 (self):
+        flags = Flags()
+        flags.dataFiles = 'data/'
+        CreateCaloCellsConfig.defineCaloCellFlags (flags)
+
+        self.assertEqual (flags.ECal.Barrel.cellsName, 'ECalBarrelModuleThetaMergedPositioned')
+        self.assertEqual (flags.ECal.Barrel.linksName, 'ECalBarrelModuleThetaMergedPositionedSimCaloHitLinks')
+        self.assertEqual (flags.ECal.Barrel.noisePath, 'data/elecNoise_ecalBarrelFCCee_theta.root')
+
+        self.assertEqual (flags.ECal.Endcap.cellsName, 'ECalEndcapTurbinePositioned')
+        self.assertEqual (flags.ECal.Endcap.linksName, 'ECalEndcapTurbinePositionedSimCaloHitLinks')
+
+        self.assertEqual (flags.HCal.Barrel.cellsName, 'HCalBarrelReadoutPositioned')
+        self.assertEqual (flags.HCal.Barrel.linksName, 'HCalBarrelReadoutPositionedSimCaloHitLinks')
+
+        self.assertEqual (flags.HCal.Endcap.cellsName, 'HCalEndcapReadoutPositioned')
+        self.assertEqual (flags.HCal.Endcap.linksName, 'HCalEndcapReadoutPositionedSimCaloHitLinks')
+        return
+        
+
+    def test_defineCaloCellFlags2 (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags (None, 'Cells', 'Links')
+
+        self.assertEqual (flags.ECal.Barrel.cellsName, 'ECalBarrelModuleThetaMergedCells')
+        self.assertEqual (flags.ECal.Barrel.linksName, 'ECalBarrelModuleThetaMergedCellsLinks')
+        self.assertEqual (flags.ECal.Barrel.noisePath, 'elecNoise_ecalBarrelFCCee_theta.root')
+
+        self.assertEqual (flags.ECal.Endcap.cellsName, 'ECalEndcapTurbineCells')
+        self.assertEqual (flags.ECal.Endcap.linksName, 'ECalEndcapTurbineCellsLinks')
+
+        self.assertEqual (flags.HCal.Barrel.cellsName, 'HCalBarrelReadoutCells')
+        self.assertEqual (flags.HCal.Barrel.linksName, 'HCalBarrelReadoutCellsLinks')
+
+        self.assertEqual (flags.HCal.Endcap.cellsName, 'HCalEndcapReadoutCells')
+        self.assertEqual (flags.HCal.Endcap.linksName, 'HCalEndcapReadoutCellsLinks')
+        return
+
+
+    def test_ECalBarrelGeometryTool (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        flags.compactFile = compactFile
+        tool = CreateCaloCellsConfig.ECalBarrelGeometryTool (flags)
+        self.assertEqual (tool.getFullName(), 'TubeLayerModuleThetaCaloTool/ECalBarrelGeometryTool')
+        return
+        
+
+    def test_ECalEndcapGeometryTool (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.ECalEndcapGeometryTool (flags)
+        self.assertEqual (tool.getFullName(), 'TurbineEndcapCaloTool/ECalEndcapGeometryTool')
+        return
+        
+
+    def test_HCalBarrelGeometryTool (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.HCalBarrelGeometryTool (flags)
+        self.assertEqual (tool.getFullName(), 'HCalPhiThetaCaloTool/HCalBarrelGeometryTool')
+        return
+        
+
+    def test_HCalEndcapGeometryTool (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.HCalEndcapGeometryTool (flags)
+        self.assertEqual (tool.getFullName(), 'HCalPhiThetaCaloTool/HCalEndcapGeometryTool')
+        return
+        
+
+    def test_CaloCellIndexerSvcCfg (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        flags.compactFile = compactFile
+        ca1 = CreateCaloCellsConfig.CaloCellIndexerSvcCfg (flags,
+                                                           detectors = ['ECAL_Barrel',
+                                                                        'ECAL_Endcap'])
+        self.assertEqual (len(ca1.svcs()), 1)
+        self.assertEqual (len(ca1.algs()), 0)
+        svc1 = ca1.svcs()[0]
+        self.assertEqual (svc1.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc1.GeoTools), 2)
+        self.assertEqual (svc1.GeoTools[0].getFullName(), 'TubeLayerModuleThetaCaloTool/ECalBarrelGeometryTool')
+        self.assertEqual (svc1.GeoTools[1].getFullName(), 'TurbineEndcapCaloTool/ECalEndcapGeometryTool')
+
+        ca2 = CreateCaloCellsConfig.CaloCellIndexerSvcCfg (flags,
+                                                           detectors = ['ECAL_Barrel',
+                                                                        'HCAL_Barrel'])
+        self.assertEqual (len(ca2.svcs()), 1)
+        self.assertEqual (len(ca2.algs()), 0)
+        svc2 = ca2.svcs()[0]
+        self.assertEqual (svc2.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc2.GeoTools), 2)
+        self.assertEqual (svc2.GeoTools[0].getFullName(), 'TubeLayerModuleThetaCaloTool/ECalBarrelGeometryTool')
+        self.assertEqual (svc2.GeoTools[1].getFullName(), 'HCalPhiThetaCaloTool/HCalBarrelGeometryTool')
+
+        ca1.merge (ca2)
+        self.assertEqual (len(ca1.svcs()), 1)
+        self.assertEqual (len(ca1.algs()), 0)
+        svc1 = ca1.svcs()[0]
+        self.assertEqual (svc1.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc1.GeoTools), 3)
+        
+        self.assertEqual (svc1.GeoTools[0].getFullName(), 'TubeLayerModuleThetaCaloTool/ECalBarrelGeometryTool')
+        self.assertEqual (svc1.GeoTools[1].getFullName(), 'TurbineEndcapCaloTool/ECalEndcapGeometryTool')
+        self.assertEqual (svc1.GeoTools[2].getFullName(), 'HCalPhiThetaCaloTool/HCalBarrelGeometryTool')
+        
+        return
+        
+
+    def test_CalibrateECalBarrel (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CalibrateECalBarrel (flags)
+        self.assertEqual (tool.getFullName(), 'CalibrateInLayersTool/CalibrateECalBarrel')
+        self.assertEqual (len(tool.samplingFraction), 11)
+        return
+
+
+    def test_CalibrateECalEndcap (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CalibrateECalEndcap (flags)
+        self.assertEqual (tool.getFullName(), 'CalibrateInLayersTool/CalibrateECalEndcap')
+        self.assertEqual (len(tool.samplingFraction), 98)
+        return
+
+
+    def test_CalibrateHCalBarrel (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CalibrateHCalBarrel (flags)
+        self.assertEqual (tool.getFullName(), 'CalibrateCaloHitsTool/CalibrateHCalBarrel')
+        self.assertEqual (tool.invSamplingFraction, 29.4202)
+        return
+
+
+    def test_CalibrateHCalEndcap (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CalibrateHCalEndcap (flags)
+        self.assertEqual (tool.getFullName(), 'CalibrateCaloHitsTool/CalibrateHCalEndcap')
+        self.assertEqual (tool.invSamplingFraction, 29.4202)
+        return
+
+
+    def test_CellPositionsECalBarrel (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CellPositionsECalBarrel (flags)
+        self.assertEqual (tool.getFullName(), 'CellPositionsECalBarrelModuleThetaSegTool/CellPositionsECalBarrel')
+        self.assertEqual (tool.readoutName, flags.ECal.Barrel.readoutName)
+        tool2 = CreateCaloCellsConfig.CellPositionsECalBarrel (flags, name='pos_emb', readoutName='ro')
+        self.assertEqual (tool2.getFullName(), 'CellPositionsECalBarrelModuleThetaSegTool/pos_emb')
+        self.assertEqual (tool2.readoutName, 'ro')
+        return
+
+
+    def test_CellPositionsECalEndcap (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CellPositionsECalEndcap (flags)
+        self.assertEqual (tool.getFullName(), 'CellPositionsECalEndcapTurbineSegTool/CellPositionsECalEndcap')
+        self.assertEqual (tool.readoutName, flags.ECal.Endcap.readoutName)
+        tool2 = CreateCaloCellsConfig.CellPositionsECalEndcap (flags, name='pos_emec', readoutName='ro')
+        self.assertEqual (tool2.getFullName(), 'CellPositionsECalEndcapTurbineSegTool/pos_emec')
+        self.assertEqual (tool2.readoutName, 'ro')
+        return
+
+
+    def test_CellPositionsHCalBarrel (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CellPositionsHCalBarrel (flags)
+        self.assertEqual (tool.getFullName(), 'CellPositionsHCalPhiThetaSegTool/CellPositionsHCalBarrel')
+        self.assertEqual (tool.readoutName, flags.HCal.Barrel.readoutName)
+        self.assertEqual (tool.detectorName, 'HCalBarrel')
+        tool2 = CreateCaloCellsConfig.CellPositionsHCalBarrel (flags, name='pos_hcalb', readoutName='ro')
+        self.assertEqual (tool2.getFullName(), 'CellPositionsHCalPhiThetaSegTool/pos_hcalb')
+        self.assertEqual (tool2.readoutName, 'ro')
+        return
+
+
+    def test_CellPositionsHCalEndcap (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.CellPositionsHCalEndcap (flags)
+        self.assertEqual (tool.getFullName(), 'CellPositionsHCalPhiThetaSegTool/CellPositionsHCalEndcap')
+        self.assertEqual (tool.readoutName, flags.HCal.Endcap.readoutName)
+        self.assertEqual (tool.detectorName, 'HCalThreePartsEndcap')
+        tool2 = CreateCaloCellsConfig.CellPositionsHCalEndcap (flags, name='pos_hcale', readoutName='ro')
+        self.assertEqual (tool2.getFullName(), 'CellPositionsHCalPhiThetaSegTool/pos_hcale')
+        self.assertEqual (tool2.readoutName, 'ro')
+        return
+
+
+    def test_ReadCrosstalkMapECalBarrel (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        flags.compactFile = compactFile
+        tool = CreateCaloCellsConfig.ReadCrosstalkMapECalBarrel (flags)
+        self.assertEqual (tool.getFullName(), 'ReadCaloCrosstalkMap/ReadCrosstalkMapECalBarrel')
+        return
+
+
+    def test_ECalBarrelNoiseTool (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.ECalBarrelNoiseTool (flags)
+        self.assertEqual (tool.getFullName(), 'NoiseCaloCellsFromFileBarrelTool/ECalBarrelNoiseTool')
+        return
+        
+
+    def test_ECalEndcapNoiseTool (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        tool = CreateCaloCellsConfig.ECalEndcapNoiseTool (flags)
+        self.assertEqual (tool.getFullName(), 'NoiseCaloCellsFromFileTurbineEndcapTool/ECalEndcapNoiseTool')
+        return
+        
+
+    def test_CreateECalBarrelCellsCfg (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+        flags.compactFile = compactFile
+
+        ca = CreateCaloCellsConfig.CreateECalBarrelCellsCfg (flags)
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/CreatePositionedECalBarrelCells')
+        self.assertEqual (alg.hits, 'ECalBarrelModuleThetaMerged')
+        self.assertEqual (alg.cells, 'ECalBarrelModuleThetaMergedPositioned')
+        self.assertEqual (alg.links, 'ECalBarrelModuleThetaMergedPositionedSimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, True)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, False)
+        self.assertEqual (alg.filterCellNoise, False)
+        self.assertEqual (alg.noiseTool.getFullName(), '')
+        self.assertEqual (alg.calibTool.getFullName(), 'CalibrateInLayersTool/CalibrateECalBarrel')
+        self.assertEqual (alg.calibTool.readoutName, 'ECalBarrelModuleThetaMerged')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsECalBarrelModuleThetaSegTool/CellPositionsECalBarrel')
+        self.assertEqual (alg.positionsTool.readoutName, 'ECalBarrelModuleThetaMerged')
+        svc = ca.svcs()[0]
+        self.assertEqual (svc.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc.GeoTools), 1)
+        self.assertEqual (svc.GeoTools[0].getFullName(), 'TubeLayerModuleThetaCaloTool/ECalBarrelGeometryTool')
+
+        ca = CreateCaloCellsConfig.CreateECalBarrelCellsCfg (flags, name='ecalb_cells2', doCellCalibration=False, hits='ecalb', cellsNameSuffix='2',
+                                                             addNoise=True, addCrosstalk=True, filterCellNoise=True)
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/ecalb_cells2')
+        self.assertEqual (alg.hits, 'ecalb')
+        self.assertEqual (alg.cells, 'ECalBarrelModuleThetaMergedPositioned2')
+        self.assertEqual (alg.links, 'ECalBarrelModuleThetaMergedPositioned2SimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, False)
+        self.assertEqual (alg.addCrosstalk, True)
+        self.assertEqual (alg.addCellNoise, True)
+        self.assertEqual (alg.filterCellNoise, True)
+        self.assertEqual (alg.noiseTool.getFullName(), 'NoiseCaloCellsFromFileBarrelTool/ECalBarrelNoiseTool')
+        self.assertEqual (alg.calibTool.getFullName(), '')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsECalBarrelModuleThetaSegTool/CellPositionsECalBarrelModuleThetaMerged')
+        self.assertEqual (alg.positionsTool.readoutName, 'ECalBarrelModuleThetaMerged')
+        self.assertEqual (alg.crosstalkTool.getFullName(), 'ReadCaloCrosstalkMap/ReadCrosstalkMapECalBarrel')
+        self.assertEqual (alg.geometryTool.getFullName(), 'TubeLayerModuleThetaCaloTool/ECalBarrelGeometryTool')
+        return
+
+
+    def test_CreateECalEndcapCellsCfg (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+
+        ca = CreateCaloCellsConfig.CreateECalEndcapCellsCfg (flags)
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/CreatePositionedECalEndcapCells')
+        self.assertEqual (alg.hits, 'ECalEndcapTurbine')
+        self.assertEqual (alg.cells, 'ECalEndcapTurbinePositioned')
+        self.assertEqual (alg.links, 'ECalEndcapTurbinePositionedSimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, True)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, False)
+        self.assertEqual (alg.filterCellNoise, False)
+        self.assertEqual (alg.noiseTool.getFullName(), '')
+        self.assertEqual (alg.calibTool.getFullName(), 'CalibrateInLayersTool/CalibrateECalEndcap')
+        self.assertEqual (alg.calibTool.readoutName, 'ECalEndcapTurbine')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsECalEndcapTurbineSegTool/CellPositionsECalEndcap')
+        self.assertEqual (alg.positionsTool.readoutName, 'ECalEndcapTurbine')
+        svc = ca.svcs()[0]
+        self.assertEqual (svc.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc.GeoTools), 1)
+        self.assertEqual (svc.GeoTools[0].getFullName(), 'TurbineEndcapCaloTool/ECalEndcapGeometryTool')
+
+        ca = CreateCaloCellsConfig.CreateECalEndcapCellsCfg (flags, name='ecale_cells2', doCellCalibration=False, hits='ecale', cellsNameSuffix='2',
+                                                             addNoise=True, filterCellNoise=True)
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/ecale_cells2')
+        self.assertEqual (alg.hits, 'ecale')
+        self.assertEqual (alg.cells, 'ECalEndcapTurbinePositioned2')
+        self.assertEqual (alg.links, 'ECalEndcapTurbinePositioned2SimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, False)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, True)
+        self.assertEqual (alg.filterCellNoise, True)
+        self.assertEqual (alg.noiseTool.getFullName(), 'NoiseCaloCellsFromFileTurbineEndcapTool/ECalEndcapNoiseTool')
+        self.assertEqual (alg.calibTool.getFullName(), '')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsECalEndcapTurbineSegTool/CellPositionsECalEndcapTurbine')
+        self.assertEqual (alg.positionsTool.readoutName, 'ECalEndcapTurbine')
+        return
+
+
+    def test_CreateHCalBarrelCellsCfg (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+
+        ca = CreateCaloCellsConfig.CreateHCalBarrelCellsCfg (flags)
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/CreatePositionedHCalBarrelCells')
+        self.assertEqual (alg.hits, 'HCalBarrelReadout')
+        self.assertEqual (alg.cells, 'HCalBarrelReadoutPositioned')
+        self.assertEqual (alg.links, 'HCalBarrelReadoutPositionedSimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, True)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, False)
+        self.assertEqual (alg.filterCellNoise, False)
+        self.assertEqual (alg.noiseTool.getFullName(), '')
+        self.assertEqual (alg.calibTool.getFullName(), 'CalibrateCaloHitsTool/CalibrateHCalBarrel')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsHCalPhiThetaSegTool/CellPositionsHCalBarrel')
+        self.assertEqual (alg.positionsTool.readoutName, 'HCalBarrelReadout')
+        svc = ca.svcs()[0]
+        self.assertEqual (svc.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc.GeoTools), 1)
+        self.assertEqual (svc.GeoTools[0].getFullName(), 'HCalPhiThetaCaloTool/HCalBarrelGeometryTool')
+
+        ca = CreateCaloCellsConfig.CreateHCalBarrelCellsCfg (flags, name='hcalb_cells2', doCellCalibration=False, hits='hcalb', cellsNameSuffix='2')
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/hcalb_cells2')
+        self.assertEqual (alg.hits, 'hcalb')
+        self.assertEqual (alg.cells, 'hcalbPositioned2')
+        self.assertEqual (alg.links, 'hcalbPositioned2SimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, False)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, False)
+        self.assertEqual (alg.filterCellNoise, False)
+        self.assertEqual (alg.noiseTool.getFullName(), '')
+        self.assertEqual (alg.calibTool.getFullName(), '')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsHCalPhiThetaSegTool/CellPositionsHCalBarrel')
+        self.assertEqual (alg.positionsTool.readoutName, 'HCalBarrelReadout')
+        return
+
+
+    def test_CreateHCalEndcapCellsCfg (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+
+        ca = CreateCaloCellsConfig.CreateHCalEndcapCellsCfg (flags)
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/CreatePositionedHCalEndcapCells')
+        self.assertEqual (alg.hits, 'HCalEndcapReadout')
+        self.assertEqual (alg.cells, 'HCalEndcapReadoutPositioned')
+        self.assertEqual (alg.links, 'HCalEndcapReadoutPositionedSimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, True)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, False)
+        self.assertEqual (alg.filterCellNoise, False)
+        self.assertEqual (alg.noiseTool.getFullName(), '')
+        self.assertEqual (alg.calibTool.getFullName(), 'CalibrateCaloHitsTool/CalibrateHCalEndcap')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsHCalPhiThetaSegTool/CellPositionsHCalEndcap')
+        self.assertEqual (alg.positionsTool.readoutName, 'HCalEndcapReadout')
+        svc = ca.svcs()[0]
+        self.assertEqual (svc.name(), 'k4::recCalo::CaloCellIndexerSvc')
+        self.assertEqual (len(svc.GeoTools), 1)
+        self.assertEqual (svc.GeoTools[0].getFullName(), 'HCalPhiThetaCaloTool/HCalEndcapGeometryTool')
+
+        ca = CreateCaloCellsConfig.CreateHCalEndcapCellsCfg (flags, name='hcale_cells2', doCellCalibration=False, hits='hcale', cellsNameSuffix='2')
+        self.assertEqual (len(ca.svcs()), 1)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'CreatePositionedCaloCells/hcale_cells2')
+        self.assertEqual (alg.hits, 'hcale')
+        self.assertEqual (alg.cells, 'hcalePositioned2')
+        self.assertEqual (alg.links, 'hcalePositioned2SimCaloHitLinks')
+        self.assertEqual (alg.doCellCalibration, False)
+        self.assertEqual (alg.addCrosstalk, False)
+        self.assertEqual (alg.addCellNoise, False)
+        self.assertEqual (alg.filterCellNoise, False)
+        self.assertEqual (alg.noiseTool.getFullName(), '')
+        self.assertEqual (alg.calibTool.getFullName(), '')
+        self.assertEqual (alg.positionsTool.getFullName(), 'CellPositionsHCalPhiThetaSegTool/CellPositionsHCalEndcap')
+        self.assertEqual (alg.positionsTool.readoutName, 'HCalEndcapReadout')
+        return
+        
+
+    def test_ReSegmentationECalBarrelCfg (self):
+        flags = CreateCaloCellsConfig.defineCaloCellFlags()
+
+        ca = CreateCaloCellsConfig.ReSegmentationECalBarrelCfg (flags)
+        self.assertEqual (len(ca.svcs()), 0)
+        self.assertEqual (len(ca.algs()), 1)
+        alg = ca.algs()[0]
+        self.assertEqual (alg.getFullName(), 'RedoSegmentation/ReSegmentationEcal')
+        self.assertEqual (alg.oldReadoutName, 'ECalBarrelModuleThetaMerged')
+        self.assertEqual (alg.newReadoutName, 'ECalBarrelModuleThetaMerged2')
+        self.assertEqual (alg.inhits.Path, 'ECalBarrelModuleThetaMergedPositioned')
+        self.assertEqual (alg.outhits.Path, 'ECalBarrelCellsMerged')
+        self.assertEqual (alg.oldSegmentationIds, ['module', 'theta'])
+        return
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/test/ComponentAccumulator_test.py
+++ b/python/test/ComponentAccumulator_test.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+#
+# File: python/test/ComponentAccumulator_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Feb, 2026
+# Purpose: Unit tests for ComponentAccumulator.
+#
+
 
 
 class TestAlg:

--- a/python/test/DetIDs_test.py
+++ b/python/test/DetIDs_test.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#
+# File: python/test/DetIDs_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Jun, 2026
+# Purpose: Unit tests for DetIDs
+#
+
+import unittest
+import os
+from FCC_config.DetIDs import detIDs
+
+
+class Flags:
+    pass
+
+class TestCreateCaloCellsConfig (unittest.TestCase):
+    def test_detIDs (self):
+        flags = Flags()
+        flags.compactFile = os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml"
+
+        self.assertEqual (detIDs (flags, 'DCH'), 3)
+        self.assertEqual (detIDs (flags, ['ECAL_Barrel', 'ECAL_Endcap']), [4, 5])
+        self.assertEqual (detIDs (flags, 'Muon_Endcap'), 13)
+        self.assertEqual (detIDs (flags, 'Muon_Endcap_1'), 13)
+        self.assertEqual (detIDs (flags, 'Muon_Endcap_2'), 14)
+        return
+        
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Introduce CreateCaloCellsConfig.py, which contains ComponentAccumulator-style configuration functions for ALLEGRO cell reconstruction.  Update configuration scripts for ALLEGRO_o1_v03 and ALLEGRO_o2_v01 to use these functions.

This is a start at factoring out common configuration code to reduce duplication.