### PR TITLE
Lambda b inclusive and exclusive semileptonic dec files

### DIFF
--- a/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
@@ -7,7 +7,7 @@ Alias Myanti-Lambda_c-  anti-Lambda_c-
 ChargeConj MyLambda_c+  Myanti-Lambda_c-
 
 Decay Lb_SIGNAL
-  0.0620    MyLambda_c+        e-  anti-e_nu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0620    MyLambda_c+        e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
 CDecay Lbbar_SIGNAL
 

--- a/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
@@ -7,7 +7,7 @@ Alias Myanti-Lambda_c-  anti-Lambda_c-
 ChargeConj MyLambda_c+  Myanti-Lambda_c-
 
 Decay Lambda_b0sig
-  0.0620    MyLambda_c+        e-  anti-e_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0620    MyLambda_c+        e-  anti-e_nu     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
 CDecay anti-Lambda_b0sig
 

--- a/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
@@ -1,0 +1,19 @@
+Alias Lambda_b0sig      Lambda_b0
+Alias anti-Lambda_b0sig anti-Lambda_b0
+ChargeConj Lambda_b0sig anti-Lambda_b0sig
+
+Alias MyLambda_c+       Lambda_c+
+Alias Myanti-Lambda_c-  anti-Lambda_c-
+ChargeConj MyLambda_c+  Myanti-Lambda_c-
+
+Decay Lambda_b0sig
+  0.0620    MyLambda_c+        e-  anti-e_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+Enddecay
+CDecay anti-Lambda_b0sig
+
+Decay MyLambda_c+
+  1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;
+Enddecay
+CDecay Myanti-Lambda_c-
+
+End

--- a/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcENu_Lc2pKpi.dec
@@ -1,15 +1,15 @@
-Alias Lambda_b0sig      Lambda_b0
-Alias anti-Lambda_b0sig anti-Lambda_b0
-ChargeConj Lambda_b0sig anti-Lambda_b0sig
-
+Alias Lb_SIGNAL      Lambda_b0
+Alias Lbbar_SIGNAL anti-Lambda_b0
+ChargeConj Lb_SIGNAL Lbbar_SIGNAL
+#
 Alias MyLambda_c+       Lambda_c+
 Alias Myanti-Lambda_c-  anti-Lambda_c-
 ChargeConj MyLambda_c+  Myanti-Lambda_c-
 
-Decay Lambda_b0sig
+Decay Lb_SIGNAL
   0.0620    MyLambda_c+        e-  anti-e_nu     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
-CDecay anti-Lambda_b0sig
+CDecay Lbbar_SIGNAL
 
 Decay MyLambda_c+
   1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;

--- a/FCCee/Generator/EvtGen/Lb2LcMuNu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcMuNu_Lc2pKpi.dec
@@ -1,15 +1,15 @@
-Alias Lambda_b0sig      Lambda_b0
-Alias anti-Lambda_b0sig anti-Lambda_b0
-ChargeConj Lambda_b0sig anti-Lambda_b0sig
-
+Alias Lb_SIGNAL      Lambda_b0
+Alias Lbbar_SIGNAL anti-Lambda_b0
+ChargeConj Lb_SIGNAL Lbbar_SIGNAL
+#
 Alias MyLambda_c+       Lambda_c+
 Alias Myanti-Lambda_c-  anti-Lambda_c-
 ChargeConj MyLambda_c+  Myanti-Lambda_c-
 
-Decay Lambda_b0sig
+Decay Lb_SIGNAL
   0.0620    MyLambda_c+        mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
-CDecay anti-Lambda_b0sig
+CDecay Lbbar_SIGNAL
 
 Decay MyLambda_c+
   1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;

--- a/FCCee/Generator/EvtGen/Lb2LcMuNu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcMuNu_Lc2pKpi.dec
@@ -1,0 +1,19 @@
+Alias Lambda_b0sig      Lambda_b0
+Alias anti-Lambda_b0sig anti-Lambda_b0
+ChargeConj Lambda_b0sig anti-Lambda_b0sig
+
+Alias MyLambda_c+       Lambda_c+
+Alias Myanti-Lambda_c-  anti-Lambda_c-
+ChargeConj MyLambda_c+  Myanti-Lambda_c-
+
+Decay Lambda_b0sig
+  0.0620    MyLambda_c+        mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+Enddecay
+CDecay anti-Lambda_b0sig
+
+Decay MyLambda_c+
+  1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;
+Enddecay
+CDecay Myanti-Lambda_c-
+
+End

--- a/FCCee/Generator/EvtGen/Lb2LcXENu_inclusive.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcXENu_inclusive.dec
@@ -1,0 +1,69 @@
+Alias Lambda_b0sig      Lambda_b0
+Alias anti-Lambda_b0sig anti-Lambda_b0
+ChargeConj Lambda_b0sig anti-Lambda_b0sig
+
+#
+Alias MyLambda_c(2593)+       Lambda_c(2593)+
+Alias Myanti-Lambda_c(2593)-  anti-Lambda_c(2593)-
+ChargeConj MyLambda_c(2593)+  Myanti-Lambda_c(2593)-
+#
+Alias MyLambda_c(2625)+       Lambda_c(2625)+
+Alias Myanti-Lambda_c(2625)-  anti-Lambda_c(2625)-
+ChargeConj MyLambda_c(2625)+  Myanti-Lambda_c(2625)-
+#
+Alias MySigma_c+       Sigma_c+
+Alias Myanti-Sigma_c-  anti-Sigma_c-
+ChargeConj MySigma_c+  Myanti-Sigma_c-
+#
+Alias MySigma_c++       Sigma_c++
+Alias Myanti-Sigma_c--  anti-Sigma_c--
+ChargeConj MySigma_c++  Myanti-Sigma_c--
+#
+Alias MySigma_c0       Sigma_c0
+Alias Myanti-Sigma_c0  anti-Sigma_c0
+ChargeConj MySigma_c0  Myanti-Sigma_c0
+#
+
+Decay Lambda_b0sig
+  0.0620    Lambda_c+        e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0079    MyLambda_c(2593)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0130    MyLambda_c(2625)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
+Enddecay
+CDecay anti-Lambda_b0sig
+
+Decay MyLambda_c(2593)+
+  0.24000      MySigma_c++         pi-         PHSP;
+  0.24000      MySigma_c0          pi+         PHSP;
+  0.18000      Lambda_c+         pi+    pi-  PHSP;
+  0.24000      MySigma_c+          pi0         PHSP;
+  0.09000      Lambda_c+         pi0    pi0  PHSP;
+  0.01000      Lambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2593)-
+#
+Decay MyLambda_c(2625)+
+  0.03420      MySigma_c++         pi-         PHSP;
+  0.03460      MySigma_c0          pi+         PHSP;
+  0.03420      MySigma_c+          pi0         PHSP;
+  0.54787      Lambda_c+         pi+    pi-  PHSP;
+  0.24913      Lambda_c+         pi0    pi0  PHSP;
+  0.01000      Lambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2625)-
+#
+Decay MySigma_c++
+  1.0000    Lambda_c+  pi+                   PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-- 
+#
+Decay MySigma_c+
+1.0000    Lambda_c+  pi0                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-
+#
+Decay MySigma_c0
+1.0000    Lambda_c+  pi-                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c0
+#
+End

--- a/FCCee/Generator/EvtGen/Lb2LcXENu_inclusive.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcXENu_inclusive.dec
@@ -1,7 +1,6 @@
-Alias Lambda_b0sig      Lambda_b0
-Alias anti-Lambda_b0sig anti-Lambda_b0
-ChargeConj Lambda_b0sig anti-Lambda_b0sig
-
+Alias Lb_SIGNAL      Lambda_b0
+Alias Lbbar_SIGNAL anti-Lambda_b0
+ChargeConj Lb_SIGNAL Lbbar_SIGNAL
 #
 Alias MyLambda_c(2593)+       Lambda_c(2593)+
 Alias Myanti-Lambda_c(2593)-  anti-Lambda_c(2593)-
@@ -24,12 +23,12 @@ Alias Myanti-Sigma_c0  anti-Sigma_c0
 ChargeConj MySigma_c0  Myanti-Sigma_c0
 #
 
-Decay Lambda_b0sig
+Decay Lb_SIGNAL
   0.0620    Lambda_c+        e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
   0.0079    MyLambda_c(2593)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
   0.0130    MyLambda_c(2625)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
-CDecay anti-Lambda_b0sig
+CDecay Lbbar_SIGNAL
 
 Decay MyLambda_c(2593)+
   0.24000      MySigma_c++         pi-         PHSP;

--- a/FCCee/Generator/EvtGen/Lb2LcXMuNu_inclusive.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcXMuNu_inclusive.dec
@@ -1,7 +1,6 @@
-Alias Lambda_b0sig      Lambda_b0
-Alias anti-Lambda_b0sig anti-Lambda_b0
-ChargeConj Lambda_b0sig anti-Lambda_b0sig
-
+Alias Lb_SIGNAL      Lambda_b0
+Alias Lbbar_SIGNAL anti-Lambda_b0
+ChargeConj Lb_SIGNAL Lbbar_SIGNAL
 #
 Alias MyLambda_c(2593)+       Lambda_c(2593)+
 Alias Myanti-Lambda_c(2593)-  anti-Lambda_c(2593)-
@@ -24,12 +23,12 @@ Alias Myanti-Sigma_c0  anti-Sigma_c0
 ChargeConj MySigma_c0  Myanti-Sigma_c0
 #
 
-Decay Lambda_b0sig
+Decay Lb_SIGNAL
   0.0620    Lambda_c+        mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
   0.0079    MyLambda_c(2593)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
   0.0130    MyLambda_c(2625)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
-CDecay anti-Lambda_b0sig
+CDecay Lbbar_SIGNAL
 
 Decay MyLambda_c(2593)+
   0.24000      MySigma_c++         pi-         PHSP;

--- a/FCCee/Generator/EvtGen/Lb2LcXMuNu_inclusive.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcXMuNu_inclusive.dec
@@ -1,0 +1,69 @@
+Alias Lambda_b0sig      Lambda_b0
+Alias anti-Lambda_b0sig anti-Lambda_b0
+ChargeConj Lambda_b0sig anti-Lambda_b0sig
+
+#
+Alias MyLambda_c(2593)+       Lambda_c(2593)+
+Alias Myanti-Lambda_c(2593)-  anti-Lambda_c(2593)-
+ChargeConj MyLambda_c(2593)+  Myanti-Lambda_c(2593)-
+#
+Alias MyLambda_c(2625)+       Lambda_c(2625)+
+Alias Myanti-Lambda_c(2625)-  anti-Lambda_c(2625)-
+ChargeConj MyLambda_c(2625)+  Myanti-Lambda_c(2625)-
+#
+Alias MySigma_c+       Sigma_c+
+Alias Myanti-Sigma_c-  anti-Sigma_c-
+ChargeConj MySigma_c+  Myanti-Sigma_c-
+#
+Alias MySigma_c++       Sigma_c++
+Alias Myanti-Sigma_c--  anti-Sigma_c--
+ChargeConj MySigma_c++  Myanti-Sigma_c--
+#
+Alias MySigma_c0       Sigma_c0
+Alias Myanti-Sigma_c0  anti-Sigma_c0
+ChargeConj MySigma_c0  Myanti-Sigma_c0
+#
+
+Decay Lambda_b0sig
+  0.0620    Lambda_c+        mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0079    MyLambda_c(2593)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0130    MyLambda_c(2625)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+Enddecay
+CDecay anti-Lambda_b0sig
+
+Decay MyLambda_c(2593)+
+  0.24000      MySigma_c++         pi-         PHSP;
+  0.24000      MySigma_c0          pi+         PHSP;
+  0.18000      Lambda_c+         pi+    pi-  PHSP;
+  0.24000      MySigma_c+          pi0         PHSP;
+  0.09000      Lambda_c+         pi0    pi0  PHSP;
+  0.01000      Lambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2593)-
+#
+Decay MyLambda_c(2625)+
+  0.03420      MySigma_c++         pi-         PHSP;
+  0.03460      MySigma_c0          pi+         PHSP;
+  0.03420      MySigma_c+          pi0         PHSP;
+  0.54787      Lambda_c+         pi+    pi-  PHSP;
+  0.24913      Lambda_c+         pi0    pi0  PHSP;
+  0.01000      Lambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2625)-
+#
+Decay MySigma_c++
+  1.0000    Lambda_c+  pi+                   PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-- 
+#
+Decay MySigma_c+
+1.0000    Lambda_c+  pi0                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-
+#
+Decay MySigma_c0
+1.0000    Lambda_c+  pi-                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c0
+#
+End

--- a/FCCee/Generator/EvtGen/Lb2LcstENu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcstENu_Lc2pKpi.dec
@@ -1,0 +1,76 @@
+Alias Lambda_b0sig      Lambda_b0
+Alias anti-Lambda_b0sig anti-Lambda_b0
+ChargeConj Lambda_b0sig anti-Lambda_b0sig
+
+Alias MyLambda_c+       Lambda_c+
+Alias Myanti-Lambda_c-  anti-Lambda_c-
+ChargeConj MyLambda_c+  Myanti-Lambda_c-
+#
+Alias MyLambda_c(2593)+       Lambda_c(2593)+
+Alias Myanti-Lambda_c(2593)-  anti-Lambda_c(2593)-
+ChargeConj MyLambda_c(2593)+  Myanti-Lambda_c(2593)-
+#
+Alias MyLambda_c(2625)+       Lambda_c(2625)+
+Alias Myanti-Lambda_c(2625)-  anti-Lambda_c(2625)-
+ChargeConj MyLambda_c(2625)+  Myanti-Lambda_c(2625)-
+#
+Alias MySigma_c+       Sigma_c+
+Alias Myanti-Sigma_c-  anti-Sigma_c-
+ChargeConj MySigma_c+  Myanti-Sigma_c-
+#
+Alias MySigma_c++       Sigma_c++
+Alias Myanti-Sigma_c--  anti-Sigma_c--
+ChargeConj MySigma_c++  Myanti-Sigma_c--
+#
+Alias MySigma_c0       Sigma_c0
+Alias Myanti-Sigma_c0  anti-Sigma_c0
+ChargeConj MySigma_c0  Myanti-Sigma_c0
+#
+
+Decay Lambda_b0sig
+  0.0079    MyLambda_c(2593)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0130    MyLambda_c(2625)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
+Enddecay
+CDecay anti-Lambda_b0sig
+
+Decay MyLambda_c+
+  1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;
+Enddecay
+CDecay Myanti-Lambda_c-
+
+Decay MyLambda_c(2593)+
+  0.24000      MySigma_c++         pi-         PHSP;
+  0.24000      MySigma_c0          pi+         PHSP;
+  0.18000      MyLambda_c+         pi+    pi-  PHSP;
+  0.24000      MySigma_c+          pi0         PHSP;
+  0.09000      MyLambda_c+         pi0    pi0  PHSP;
+  0.01000      MyLambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2593)-
+#
+Decay MyLambda_c(2625)+
+  0.03420      MySigma_c++         pi-         PHSP;
+  0.03460      MySigma_c0          pi+         PHSP;
+  0.03420      MySigma_c+          pi0         PHSP;
+  0.54787      MyLambda_c+         pi+    pi-  PHSP;
+  0.24913      MyLambda_c+         pi0    pi0  PHSP;
+  0.01000      MyLambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2625)-
+#
+Decay MySigma_c++
+  1.0000    MyLambda_c+  pi+                   PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-- 
+#
+Decay MySigma_c+
+1.0000    MyLambda_c+  pi0                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-
+#
+Decay MySigma_c0
+1.0000    MyLambda_c+  pi-                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c0
+#
+End

--- a/FCCee/Generator/EvtGen/Lb2LcstENu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcstENu_Lc2pKpi.dec
@@ -1,7 +1,7 @@
-Alias Lambda_b0sig      Lambda_b0
-Alias anti-Lambda_b0sig anti-Lambda_b0
-ChargeConj Lambda_b0sig anti-Lambda_b0sig
-
+Alias Lb_SIGNAL      Lambda_b0
+Alias Lbbar_SIGNAL anti-Lambda_b0
+ChargeConj Lb_SIGNAL Lbbar_SIGNAL
+#
 Alias MyLambda_c+       Lambda_c+
 Alias Myanti-Lambda_c-  anti-Lambda_c-
 ChargeConj MyLambda_c+  Myanti-Lambda_c-
@@ -27,11 +27,11 @@ Alias Myanti-Sigma_c0  anti-Sigma_c0
 ChargeConj MySigma_c0  Myanti-Sigma_c0
 #
 
-Decay Lambda_b0sig
+Decay Lb_SIGNAL
   0.0079    MyLambda_c(2593)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
   0.0130    MyLambda_c(2625)+  e-  anti-nu_e     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
-CDecay anti-Lambda_b0sig
+CDecay Lbbar_SIGNAL
 
 Decay MyLambda_c+
   1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;

--- a/FCCee/Generator/EvtGen/Lb2LcstMuNu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcstMuNu_Lc2pKpi.dec
@@ -1,0 +1,76 @@
+Alias Lambda_b0sig      Lambda_b0
+Alias anti-Lambda_b0sig anti-Lambda_b0
+ChargeConj Lambda_b0sig anti-Lambda_b0sig
+
+Alias MyLambda_c+       Lambda_c+
+Alias Myanti-Lambda_c-  anti-Lambda_c-
+ChargeConj MyLambda_c+  Myanti-Lambda_c-
+#
+Alias MyLambda_c(2593)+       Lambda_c(2593)+
+Alias Myanti-Lambda_c(2593)-  anti-Lambda_c(2593)-
+ChargeConj MyLambda_c(2593)+  Myanti-Lambda_c(2593)-
+#
+Alias MyLambda_c(2625)+       Lambda_c(2625)+
+Alias Myanti-Lambda_c(2625)-  anti-Lambda_c(2625)-
+ChargeConj MyLambda_c(2625)+  Myanti-Lambda_c(2625)-
+#
+Alias MySigma_c+       Sigma_c+
+Alias Myanti-Sigma_c-  anti-Sigma_c-
+ChargeConj MySigma_c+  Myanti-Sigma_c-
+#
+Alias MySigma_c++       Sigma_c++
+Alias Myanti-Sigma_c--  anti-Sigma_c--
+ChargeConj MySigma_c++  Myanti-Sigma_c--
+#
+Alias MySigma_c0       Sigma_c0
+Alias Myanti-Sigma_c0  anti-Sigma_c0
+ChargeConj MySigma_c0  Myanti-Sigma_c0
+#
+
+Decay Lambda_b0sig
+  0.0079    MyLambda_c(2593)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+  0.0130    MyLambda_c(2625)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
+Enddecay
+CDecay anti-Lambda_b0sig
+
+Decay MyLambda_c+
+  1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;
+Enddecay
+CDecay Myanti-Lambda_c-
+
+Decay MyLambda_c(2593)+
+  0.24000      MySigma_c++         pi-         PHSP;
+  0.24000      MySigma_c0          pi+         PHSP;
+  0.18000      MyLambda_c+         pi+    pi-  PHSP;
+  0.24000      MySigma_c+          pi0         PHSP;
+  0.09000      MyLambda_c+         pi0    pi0  PHSP;
+  0.01000      MyLambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2593)-
+#
+Decay MyLambda_c(2625)+
+  0.03420      MySigma_c++         pi-         PHSP;
+  0.03460      MySigma_c0          pi+         PHSP;
+  0.03420      MySigma_c+          pi0         PHSP;
+  0.54787      MyLambda_c+         pi+    pi-  PHSP;
+  0.24913      MyLambda_c+         pi0    pi0  PHSP;
+  0.01000      MyLambda_c+         gamma       PHSP;
+Enddecay
+CDecay Myanti-Lambda_c(2625)-
+#
+Decay MySigma_c++
+  1.0000    MyLambda_c+  pi+                   PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-- 
+#
+Decay MySigma_c+
+1.0000    MyLambda_c+  pi0                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c-
+#
+Decay MySigma_c0
+1.0000    MyLambda_c+  pi-                     PHSP;
+Enddecay
+CDecay Myanti-Sigma_c0
+#
+End

--- a/FCCee/Generator/EvtGen/Lb2LcstMuNu_Lc2pKpi.dec
+++ b/FCCee/Generator/EvtGen/Lb2LcstMuNu_Lc2pKpi.dec
@@ -1,7 +1,7 @@
-Alias Lambda_b0sig      Lambda_b0
-Alias anti-Lambda_b0sig anti-Lambda_b0
-ChargeConj Lambda_b0sig anti-Lambda_b0sig
-
+Alias Lb_SIGNAL      Lambda_b0
+Alias Lbbar_SIGNAL anti-Lambda_b0
+ChargeConj Lb_SIGNAL Lbbar_SIGNAL
+#
 Alias MyLambda_c+       Lambda_c+
 Alias Myanti-Lambda_c-  anti-Lambda_c-
 ChargeConj MyLambda_c+  Myanti-Lambda_c-
@@ -27,11 +27,11 @@ Alias Myanti-Sigma_c0  anti-Sigma_c0
 ChargeConj MySigma_c0  Myanti-Sigma_c0
 #
 
-Decay Lambda_b0sig
+Decay Lb_SIGNAL
   0.0079    MyLambda_c(2593)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
   0.0130    MyLambda_c(2625)+  mu-  anti-nu_mu     PHOTOS Lb2Baryonlnu 1 1 1 1;
 Enddecay
-CDecay anti-Lambda_b0sig
+CDecay Lbbar_SIGNAL
 
 Decay MyLambda_c+
   1.000         p+      K-      pi+          PHOTOS LAMBDAC_PHH;


### PR DESCRIPTION
Adds six new EvtGen dec files for $\Lambda_b$ semileptonic $b \to c$ decays. Three for muons and three for electrons:
- Exclusive ground-state $\Lambda_c$, with $\Lambda_c \to pK\pi$
- Exclusive excited $\Lambda_c^* \to \Lambda_c \pi\pi$, with $\Lambda_c \to pK\pi$
- Inclusive $\Lambda_c$ and $\Lambda_c^*$, with $\Lambda_c$ to anything (decay according to default DECAY.DEC)

Additional decays with $D^0 p$ and $D^+ n$ for full inclusive would inquire adding additional particles to EvtGen.